### PR TITLE
Add win conditions and progressive rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ This repository contains a basic static website structure.
 
 - `index.html` - The main HTML page.
 - `css/style.css` - Styles for the website.
-- `js/app.js` - Simple JavaScript functionality.
+- `js/app.js` - Game logic with a simple computer opponent, win conditions,
+  and increasing difficulty each round.
 - `images/` - Placeholder directory for site images.

--- a/index.html
+++ b/index.html
@@ -14,8 +14,17 @@
         <div id="info">
             <p>Deck: <span id="deckCount">0</span> |
                Discard: <span id="discardCount">0</span> |
-               Turn: <span id="turnNumber">0</span></p>
-            <p>Coins: <span id="coinCount">0</span></p>
+               Turn: <span id="turnNumber">0</span> |
+               Round: <span id="roundNumber">1</span></p>
+            <p>Coins: <span id="coinCount">0</span> |
+               VP: <span id="vpCount">0</span></p>
+        </div>
+
+        <div id="aiInfo">
+            <p>AI Deck: <span id="aiDeckCount">0</span> |
+               AI Discard: <span id="aiDiscardCount">0</span></p>
+            <p>AI Coins: <span id="aiCoinCount">0</span> |
+               AI VP: <span id="aiVpCount">0</span></p>
         </div>
 
         <div id="handArea">

--- a/js/app.js
+++ b/js/app.js
@@ -12,7 +12,14 @@ document.addEventListener('DOMContentLoaded', () => {
     let hand = [];
     let coins = 0;
     let turn = 0;
+    let round = 1;
     let bought = false;
+
+    // AI state
+    let aiDeck = [];
+    let aiDiscard = [];
+    let aiHand = [];
+    let aiCoins = 0;
 
     const newGameBtn = document.getElementById('newGame');
     const gameArea = document.getElementById('gameArea');
@@ -24,6 +31,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const turnNumber = document.getElementById('turnNumber');
     const message = document.getElementById('message');
     const endTurnBtn = document.getElementById('endTurn');
+    const roundNumber = document.getElementById('roundNumber');
+    const vpCount = document.getElementById('vpCount');
+    const aiVpCount = document.getElementById('aiVpCount');
+
+    // AI DOM elements
+    const aiDeckCount = document.getElementById('aiDeckCount');
+    const aiDiscardCount = document.getElementById('aiDiscardCount');
+    const aiCoinCount = document.getElementById('aiCoinCount');
 
     function shuffle(array) {
         for (let i = array.length - 1; i > 0; i--) {
@@ -44,8 +59,28 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function aiDraw(n) {
+        for (let i = 0; i < n; i++) {
+            if (aiDeck.length === 0) {
+                aiDeck = aiDiscard;
+                aiDiscard = [];
+                shuffle(aiDeck);
+            }
+            if (aiDeck.length === 0) return;
+            aiHand.push(aiDeck.pop());
+        }
+    }
+
     function countCoins() {
         coins = hand.reduce((sum, card) => sum + (cardData[card].coins || 0), 0);
+    }
+
+    function countAiCoins() {
+        aiCoins = aiHand.reduce((sum, card) => sum + (cardData[card].coins || 0), 0);
+    }
+
+    function calculateVP(arr) {
+        return arr.reduce((sum, c) => sum + (cardData[c].vp || 0), 0);
     }
 
     function updateDisplay() {
@@ -53,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
         discardCount.textContent = discard.length;
         coinCount.textContent = coins;
         turnNumber.textContent = turn;
+        roundNumber.textContent = round;
         handDiv.innerHTML = '';
         hand.forEach(c => {
             const div = document.createElement('div');
@@ -60,6 +96,11 @@ document.addEventListener('DOMContentLoaded', () => {
             div.textContent = c;
             handDiv.appendChild(div);
         });
+        aiDeckCount.textContent = aiDeck.length;
+        aiDiscardCount.textContent = aiDiscard.length;
+        aiCoinCount.textContent = aiCoins;
+        vpCount.textContent = calculateVP(deck) + calculateVP(discard) + calculateVP(hand);
+        aiVpCount.textContent = calculateVP(aiDeck) + calculateVP(aiDiscard) + calculateVP(aiHand);
     }
 
     function setupMarket() {
@@ -80,15 +121,27 @@ document.addEventListener('DOMContentLoaded', () => {
         coins = 0;
         turn = 1;
         bought = false;
+        aiDeck = [];
+        aiDiscard = [];
+        aiHand = [];
+        aiCoins = 0;
         for (let i = 0; i < 7; i++) deck.push('Copper');
         for (let i = 0; i < 3; i++) deck.push('Estate');
+        for (let i = 0; i < 7; i++) aiDeck.push('Copper');
+        for (let i = 0; i < 3; i++) aiDeck.push('Estate');
+        for (let i = 0; i < round - 1; i++) aiDeck.push('Silver');
         shuffle(deck);
+        shuffle(aiDeck);
         draw(5);
+        aiDraw(5);
         countCoins();
+        countAiCoins();
+        endTurnBtn.disabled = false;
         setupMarket();
         gameArea.classList.remove('hidden');
         updateDisplay();
         message.textContent = '';
+        checkWin();
     }
 
     function buyCard(name) {
@@ -106,6 +159,38 @@ document.addEventListener('DOMContentLoaded', () => {
         bought = true;
         message.textContent = `Bought ${name}!`;
         updateDisplay();
+        checkWin();
+    }
+
+    function aiTurn() {
+        countAiCoins();
+        let choice = null;
+        const options = Object.keys(cardData)
+            .filter(n => cardData[n].cost <= aiCoins)
+            .sort((a, b) => cardData[b].cost - cardData[a].cost);
+        if (options.length > 0) {
+            choice = options[0];
+            aiCoins -= cardData[choice].cost;
+            aiDiscard.push(choice);
+        }
+        aiDiscard = aiDiscard.concat(aiHand);
+        aiHand = [];
+        aiDraw(5);
+        countAiCoins();
+        checkWin();
+        return choice ? `AI bought ${choice}!` : 'AI bought nothing.';
+    }
+
+    function checkWin() {
+        const playerVP = calculateVP(deck) + calculateVP(discard) + calculateVP(hand);
+        const enemyVP = calculateVP(aiDeck) + calculateVP(aiDiscard) + calculateVP(aiHand);
+        if (playerVP >= 15 || enemyVP >= 15) {
+            const winner = playerVP > enemyVP ? 'You' : 'AI';
+            message.textContent = `${winner} win round ${round}! Click New Game for next round.`;
+            endTurnBtn.disabled = true;
+            marketDiv.querySelectorAll('button').forEach(b => b.disabled = true);
+            round++;
+        }
     }
 
     function endTurn() {
@@ -114,9 +199,11 @@ document.addEventListener('DOMContentLoaded', () => {
         bought = false;
         draw(5);
         countCoins();
+        const aiMsg = aiTurn();
         turn++;
         updateDisplay();
-        message.textContent = '';
+        message.textContent = aiMsg;
+        checkWin();
     }
 
     newGameBtn.addEventListener('click', startGame);


### PR DESCRIPTION
## Summary
- display VP totals and round information
- increase AI starting deck each round
- detect winner when either side hits 15 VP
- disable actions until new game after a win

## Testing
- `node -c js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6840ea4ae1bc832c975423df9696ba54