### PR TITLE
Set up GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+

--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ This repository contains a basic static website structure.
 - `js/app.js` - Game logic with a simple computer opponent, win conditions,
   and increasing difficulty each round.
 - `images/` - Placeholder directory for site images.
+
+## Deployment
+
+A GitHub Actions workflow (`.github/workflows/deploy.yml`) publishes the site to
+GitHub Pages whenever changes are pushed to the `main` branch. After enabling
+GitHub Pages in the repository settings, you can access the latest version of
+the site from the URL reported in the workflow logs.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that publishes the site to GitHub Pages on each push to `main`
- document the deployment process in the README

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6840edf1e2fc832c9e5f42e01fc5b7ab