### PR TITLE
Add actions permission for artifact downloads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 concurrency:
   group: 'pages'


### PR DESCRIPTION
## Summary
- include `actions: read` permission to allow actions artifact downloads

## Testing
- `git diff --name-only --cached`


------
https://chatgpt.com/codex/tasks/task_e_6840f1042688832cb8fd1fdf6c63140c