### PR TITLE
Add card descriptions and improved style

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This repository contains a basic static website structure.
 ## Contents
 
 - `index.html` - The main HTML page.
-- `css/style.css` - Styles for the website.
+- `css/style.css` - Styles for the website and card layout.
 - `js/app.js` - Game logic with a simple computer opponent, win conditions,
-  and increasing difficulty each round.
+  increasing difficulty each round, and card descriptions.
 - `images/` - Placeholder directory for site images.
 
 ## Deployment
@@ -16,3 +16,8 @@ A GitHub Actions workflow (`.github/workflows/deploy.yml`) publishes the site to
 GitHub Pages whenever changes are pushed to the `main` branch. After enabling
 GitHub Pages in the repository settings, you can access the latest version of
 the site from the URL reported in the workflow logs.
+
+## Updates
+
+- Card descriptions appear in the market and on hover in your hand.
+- Refreshed visuals with cleaner card layout and styled buttons.

--- a/css/style.css
+++ b/css/style.css
@@ -3,6 +3,7 @@ body {
     margin: 0;
     padding: 0;
     text-align: center;
+    background: #fafafa;
 }
 
 h1 {
@@ -18,9 +19,32 @@ h1 {
 
 .card {
     border: 1px solid #333;
-    padding: 5px 10px;
+    padding: 8px 10px;
     margin: 5px;
-    background: #f5f5f5;
+    background: linear-gradient(#ffffff, #e0e0e0);
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.market-card {
+    width: 160px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.card-title {
+    font-weight: bold;
+    margin-bottom: 4px;
+}
+
+.card-desc {
+    font-size: 0.9em;
+    margin-bottom: 4px;
+}
+
+.card-cost {
+    margin-bottom: 4px;
 }
 
 .hidden {
@@ -29,4 +53,15 @@ h1 {
 
 button {
     margin: 5px;
+    padding: 6px 10px;
+    border: none;
+    background: #4caf50;
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:disabled {
+    background: #888;
+    cursor: default;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -1,10 +1,30 @@
 document.addEventListener('DOMContentLoaded', () => {
     const cardData = {
-        Copper: { cost: 0, coins: 1 },
-        Silver: { cost: 3, coins: 2 },
-        Gold: { cost: 6, coins: 3 },
-        Estate: { cost: 2, vp: 1 },
-        Province: { cost: 8, vp: 6 }
+        Copper: {
+            cost: 0,
+            coins: 1,
+            description: 'Basic currency worth 1 coin.'
+        },
+        Silver: {
+            cost: 3,
+            coins: 2,
+            description: 'Provides 2 coins.'
+        },
+        Gold: {
+            cost: 6,
+            coins: 3,
+            description: 'Provides 3 coins.'
+        },
+        Estate: {
+            cost: 2,
+            vp: 1,
+            description: 'Worth 1 victory point.'
+        },
+        Province: {
+            cost: 8,
+            vp: 6,
+            description: 'Worth 6 victory points.'
+        }
     };
 
     let deck = [];
@@ -94,6 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const div = document.createElement('div');
             div.className = 'card';
             div.textContent = c;
+            div.title = cardData[c].description;
             handDiv.appendChild(div);
         });
         aiDeckCount.textContent = aiDeck.length;
@@ -107,10 +128,30 @@ document.addEventListener('DOMContentLoaded', () => {
         marketDiv.innerHTML = '';
         Object.keys(cardData).forEach(name => {
             const data = cardData[name];
+            const card = document.createElement('div');
+            card.className = 'card market-card';
+
+            const title = document.createElement('div');
+            title.className = 'card-title';
+            title.textContent = name;
+
+            const desc = document.createElement('div');
+            desc.className = 'card-desc';
+            desc.textContent = data.description;
+
+            const cost = document.createElement('div');
+            cost.className = 'card-cost';
+            cost.textContent = `Cost: ${data.cost}`;
+
             const btn = document.createElement('button');
-            btn.textContent = `Buy ${name} (${data.cost})`;
+            btn.textContent = 'Buy';
             btn.addEventListener('click', () => buyCard(name));
-            marketDiv.appendChild(btn);
+
+            card.appendChild(title);
+            card.appendChild(desc);
+            card.appendChild(cost);
+            card.appendChild(btn);
+            marketDiv.appendChild(card);
         });
     }
 


### PR DESCRIPTION
## Summary
- add description text to each card
- show description on hover and in market display
- build market cards with titles, descriptions, and buy button
- refresh styles for cards and buttons
- document updates in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac056d38832cbca149d751888157