### PR TITLE
Improve card descriptions and UI style

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ the site from the URL reported in the workflow logs.
 
 ## Updates
 
-- Card descriptions appear in the market and on hover in your hand.
-- Refreshed visuals with cleaner card layout and styled buttons.
+- Card descriptions appear in the market and directly on cards in your hand.
+- Refreshed visuals with cleaner card layout, styled buttons, and highlighted
+  game info boxes.

--- a/css/style.css
+++ b/css/style.css
@@ -33,6 +33,13 @@ h1 {
     align-items: center;
 }
 
+.hand-card {
+    width: 140px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 .card-title {
     font-weight: bold;
     margin-bottom: 4px;
@@ -64,4 +71,26 @@ button {
 button:disabled {
     background: #888;
     cursor: default;
+}
+
+#gameArea {
+    margin-top: 20px;
+}
+
+#info, #aiInfo {
+    display: inline-block;
+    margin: 0.5em;
+    padding: 0.5em 1em;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+}
+
+#handArea, #market {
+    margin-top: 1em;
+}
+
+#message {
+    font-weight: bold;
+    margin-top: 1em;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -111,11 +111,21 @@ document.addEventListener('DOMContentLoaded', () => {
         roundNumber.textContent = round;
         handDiv.innerHTML = '';
         hand.forEach(c => {
-            const div = document.createElement('div');
-            div.className = 'card';
-            div.textContent = c;
-            div.title = cardData[c].description;
-            handDiv.appendChild(div);
+            const card = document.createElement('div');
+            card.className = 'card hand-card';
+
+            const title = document.createElement('div');
+            title.className = 'card-title';
+            title.textContent = c;
+
+            const desc = document.createElement('div');
+            desc.className = 'card-desc';
+            desc.textContent = cardData[c].description;
+
+            card.title = cardData[c].description;
+            card.appendChild(title);
+            card.appendChild(desc);
+            handDiv.appendChild(card);
         });
         aiDeckCount.textContent = aiDeck.length;
         aiDiscardCount.textContent = aiDiscard.length;


### PR DESCRIPTION
## Summary
- display card descriptions in the player's hand
- add styling for game info sections and general layout
- document the new look in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841acfe719c832c8969416ad2e08d9f