### PR TITLE
Enable card selection for purchases

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,6 +24,7 @@ h1 {
     background: linear-gradient(#ffffff, #e0e0e0);
     border-radius: 6px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: transform 0.3s, opacity 0.3s;
 }
 
 .market-card {
@@ -38,6 +39,20 @@ h1 {
     display: flex;
     flex-direction: column;
     align-items: center;
+}
+
+.selectable {
+    cursor: pointer;
+}
+
+.selected {
+    transform: translateY(-10px);
+    border-color: #4caf50;
+}
+
+.spent {
+    opacity: 0;
+    transform: translateY(20px);
 }
 
 .card-title {


### PR DESCRIPTION
## Summary
- allow picking currency cards when buying
- animate card selection and spending

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841aebcd0c8832cb0fc964da1fc8c41