### PR TITLE
Improve card layout and scoreboard

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,20 +25,15 @@ h1 {
     border-radius: 6px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     transition: transform 0.3s, opacity 0.3s;
-}
-
-.market-card {
-    width: 160px;
+    width: 150px;
     display: flex;
     flex-direction: column;
     align-items: center;
 }
 
+.market-card,
 .hand-card {
-    width: 140px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+    /* Classes kept for future extension */
 }
 
 .selectable {
@@ -97,13 +92,25 @@ button:disabled {
     margin-top: 20px;
 }
 
+#scoreboard {
+    display: flex;
+    justify-content: center;
+    gap: 1em;
+    margin: 0.5em 0;
+}
+
 #info, #aiInfo {
-    display: inline-block;
-    margin: 0.5em;
-    padding: 0.5em 1em;
     background: #fff;
     border: 1px solid #ccc;
     border-radius: 6px;
+    padding: 0.5em 1em;
+    min-width: 220px;
+    text-align: left;
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+}
+
+#info p, #aiInfo p {
+    margin: 0.2em 0;
 }
 
 #handArea, #market {

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <button id="newGame">New Game</button>
 
     <div id="gameArea" class="hidden">
+        <div id="scoreboard">
         <div id="info">
             <p>Deck: <span id="deckCount">0</span> |
                Discard: <span id="discardCount">0</span> |
@@ -25,6 +26,7 @@
                AI Discard: <span id="aiDiscardCount">0</span></p>
             <p>AI Coins: <span id="aiCoinCount">0</span> |
                AI VP: <span id="aiVpCount">0</span></p>
+        </div>
         </div>
 
         <div id="handArea">

--- a/js/app.js
+++ b/js/app.js
@@ -103,6 +103,25 @@ document.addEventListener('DOMContentLoaded', () => {
         return arr.reduce((sum, c) => sum + (cardData[c].vp || 0), 0);
     }
 
+    function createCardElement(name) {
+        const data = cardData[name];
+        const card = document.createElement('div');
+        card.className = 'card';
+
+        const title = document.createElement('div');
+        title.className = 'card-title';
+        title.textContent = name;
+
+        const desc = document.createElement('div');
+        desc.className = 'card-desc';
+        desc.textContent = data.description;
+
+        card.title = data.description;
+        card.appendChild(title);
+        card.appendChild(desc);
+        return card;
+    }
+
     function getSelectedCoinTotal() {
         let total = 0;
         selectedCards.forEach(i => {
@@ -132,23 +151,11 @@ document.addEventListener('DOMContentLoaded', () => {
         roundNumber.textContent = round;
         handDiv.innerHTML = '';
         hand.forEach((c, idx) => {
-            const card = document.createElement('div');
-            card.className = 'card hand-card selectable';
+            const card = createCardElement(c);
+            card.classList.add('hand-card', 'selectable');
             card.dataset.index = idx;
             if (selectedCards.has(idx)) card.classList.add('selected');
             card.addEventListener('click', () => toggleCardSelection(idx));
-
-            const title = document.createElement('div');
-            title.className = 'card-title';
-            title.textContent = c;
-
-            const desc = document.createElement('div');
-            desc.className = 'card-desc';
-            desc.textContent = cardData[c].description;
-
-            card.title = cardData[c].description;
-            card.appendChild(title);
-            card.appendChild(desc);
             handDiv.appendChild(card);
         });
         aiDeckCount.textContent = aiDeck.length;
@@ -162,16 +169,8 @@ document.addEventListener('DOMContentLoaded', () => {
         marketDiv.innerHTML = '';
         Object.keys(cardData).forEach(name => {
             const data = cardData[name];
-            const card = document.createElement('div');
-            card.className = 'card market-card';
-
-            const title = document.createElement('div');
-            title.className = 'card-title';
-            title.textContent = name;
-
-            const desc = document.createElement('div');
-            desc.className = 'card-desc';
-            desc.textContent = data.description;
+            const card = createCardElement(name);
+            card.classList.add('market-card');
 
             const cost = document.createElement('div');
             cost.className = 'card-cost';
@@ -181,8 +180,6 @@ document.addEventListener('DOMContentLoaded', () => {
             btn.textContent = 'Buy';
             btn.addEventListener('click', () => buyCard(name, card));
 
-            card.appendChild(title);
-            card.appendChild(desc);
             card.appendChild(cost);
             card.appendChild(btn);
             marketDiv.appendChild(card);


### PR DESCRIPTION
## Summary
- create a helper for card markup and reuse it
- give hand and market cards a unified style
- wrap player/AI stats in a scoreboard container and tweak the styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68439fc49cb4832c9977ecb371f39f26