### PR TITLE
Make market cards match hand layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,6 +36,19 @@ h1 {
     /* Classes kept for future extension */
 }
 
+/* wrapper around market cards to hold controls */
+.market-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 5px;
+}
+
+/* remove extra margin on cards inside wrapper */
+.market-card .card {
+    margin: 0 0 4px 0;
+}
+
 .selectable {
     cursor: pointer;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -169,8 +169,11 @@ document.addEventListener('DOMContentLoaded', () => {
         marketDiv.innerHTML = '';
         Object.keys(cardData).forEach(name => {
             const data = cardData[name];
+
+            const wrapper = document.createElement('div');
+            wrapper.className = 'market-card';
+
             const card = createCardElement(name);
-            card.classList.add('market-card');
 
             const cost = document.createElement('div');
             cost.className = 'card-cost';
@@ -178,11 +181,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const btn = document.createElement('button');
             btn.textContent = 'Buy';
-            btn.addEventListener('click', () => buyCard(name, card));
+            btn.addEventListener('click', () => buyCard(name, wrapper));
 
-            card.appendChild(cost);
-            card.appendChild(btn);
-            marketDiv.appendChild(card);
+            wrapper.appendChild(card);
+            wrapper.appendChild(cost);
+            wrapper.appendChild(btn);
+            marketDiv.appendChild(wrapper);
         });
     }
 


### PR DESCRIPTION
## Summary
- wrap market cards in a container so cost and buy button sit outside the card
- style wrapper so both hand and market cards share appearance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843a0f3df80832ca58989505e3e42f7