### PR TITLE
Improve card layout consistency

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -26,8 +26,11 @@ h1 {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     transition: transform 0.3s, opacity 0.3s;
     width: 150px;
+    height: 180px;
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     align-items: center;
 }
 
@@ -42,11 +45,17 @@ h1 {
     flex-direction: column;
     align-items: center;
     margin: 5px;
+    width: 150px;
 }
 
 /* remove extra margin on cards inside wrapper */
 .market-card .card {
     margin: 0 0 4px 0;
+}
+
+.market-card button,
+.market-card .card-cost {
+    width: 100%;
 }
 
 .selectable {


### PR DESCRIPTION
## Summary
- make `.card` height fixed with flex layout
- ensure market card wrappers are the same width as cards
- make cost and buy button expand to full width

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68479b780f40832c97b1be205658c5c7