### PR TITLE
Move card data to JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,65 @@ the site from the URL reported in the workflow logs.
 - Adjusted costs for several cards to better balance play.
 - The AI now gains Militia cards in later rounds, creating direct competition
   by reducing your available coins when it draws them.
-- Expanded the card set to 50 medieval-themed cards featuring offense,
-  defense and resource abilities.
+- Expanded the card set to over 150 medieval-themed cards with a mix of
+  offense, defense and resource abilities.
 - Added a defense stat that offsets attack damage and updated the market to
   include every card type each round.
 - The market now refreshes all cards at the end of each turn.
+
+## Card Data
+
+All card definitions live in `js/cards.json`. Each entry lists the card's cost,
+description and any bonus effects like extra coins or draws. Modify this file to
+create new cards or adjust existing ones.
+
+## New Card Effects
+
+Five additional mechanics appear on late-game cards:
+
+- **Discount** – cards in your hand reduce purchase costs by 1 coin each.
+- **Coin on Buy** – grants bonus coins immediately when you purchase the card.
+- **Draw on Buy** – draw extra cards right after buying the card.
+- **Attack on Buy** – cuts the opponent's coins when the card is purchased.
+- **VP on Buy** – awards victory points the moment you acquire the card.
+
+### Multipliers and Dividers
+
+Some late-game cards modify other effects by multiplication or division:
+
+- **Coin Multiplier** – multiplies the total coins provided by your hand.
+- **Coin Divider** – divides the coins from your hand (rounded down).
+- **Draw Multiplier** – multiplies any extra card draw you would gain.
+- **Draw Divider** – divides bonus draw amounts (rounded down).
+- **Attack Multiplier** – multiplies attack values when dealing damage.
+- **Attack Divider** – reduces attack values by dividing them.
+- **Defense Multiplier** – multiplies defense when blocking attacks.
+- **Defense Divider** – divides defense amounts before they absorb damage.
+
+## Game Rules
+
+- Each player starts with a deck of seven **Copper** cards and three **Estate** cards.
+- Draw five cards at the start of your turn plus any bonus cards granted by your hand.
+- Select coin cards in your hand and click **Buy** under a market card to purchase it.
+- Attack cards reduce your opponent's coins while defense cards block incoming attack.
+- After you end your turn, the AI takes its own turn.
+- The first player to reach **15 victory points** wins the round.
+
+## Working with Codex
+
+Codex provides a terminal for editing files and running commands. After making
+changes you can verify the game code with:
+
+```bash
+node --check js/app.js
+```
+
+Open `index.html` in a browser to play locally and confirm your changes.
+
+## Contributing and Pull Requests
+
+1. Create a new branch from `main` and commit your changes with clear messages.
+2. Push the branch to your fork or repository.
+3. Open a pull request on GitHub describing the changes and their purpose.
+
+When your PR is merged, GitHub Actions will deploy the updated site.

--- a/js/app.js
+++ b/js/app.js
@@ -1,343 +1,14 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const cardData = {
-        Copper: {
-            cost: 0,
-            coins: 1,
-            emoji: '🪙',
-            description: 'Basic currency worth 1 coin.'
-        },
-        Silver: {
-            cost: 3,
-            coins: 2,
-            emoji: '🥈',
-            description: 'Shiny coin worth 2 coins.'
-        },
-        Gold: {
-            cost: 6,
-            coins: 3,
-            emoji: '🥇',
-            description: 'Premium coin worth 3 coins.'
-        },
-        Estate: {
-            cost: 2,
-            vp: 1,
-            emoji: '🏠',
-            description: 'Worth 1 victory point.'
-        },
-        Duchy: {
-            cost: 5,
-            vp: 3,
-            emoji: '🏯',
-            description: 'Worth 3 victory points.'
-        },
-        Province: {
-            cost: 9,
-            vp: 6,
-            emoji: '🏰',
-            description: 'Worth 6 victory points.'
-        },
-        Jester: {
-            cost: 5,
-            coins: 1,
-            vp: 1,
-            emoji: '🤹',
-            description: 'Adds comic relief and 1 VP.'
-        },
-        Village: {
-            cost: 4,
-            coins: 1,
-            extraDraw: 1,
-            emoji: '🏘️',
-            description: 'Draw an extra card each turn.'
-        },
-        Militia: {
-            cost: 4,
-            coins: 2,
-            attack: 1,
-            emoji: '⚔️',
-            description: "Reduces opponent's coins by 1 when in hand."
-        },
-        Squire: {
-            cost: 3,
-            coins: 1,
-            defense: 1,
-            emoji: '🛡️',
-            description: 'Young warrior providing 1 defense.'
-        },
-        Knight: {
-            cost: 6,
-            coins: 1,
-            attack: 2,
-            defense: 1,
-            emoji: '🗡️',
-            description: 'Seasoned fighter with 2 attack and 1 defense.'
-        },
-        Archer: {
-            cost: 4,
-            attack: 1,
-            extraDraw: 1,
-            emoji: '🏹',
-            description: 'Ranged unit drawing a card when played.'
-        },
-        SiegeTower: {
-            cost: 7,
-            attack: 2,
-            emoji: '🪜',
-            description: 'Large engine bringing 2 attack.'
-        },
-        Castle: {
-            cost: 8,
-            vp: 4,
-            defense: 2,
-            emoji: '🏰',
-            description: 'Stronghold worth 4 VP and 2 defense.'
-        },
-        Guard: {
-            cost: 3,
-            coins: 1,
-            defense: 1,
-            emoji: '🛡️',
-            description: 'Basic protection adding 1 defense.'
-        },
-        Moat: {
-            cost: 2,
-            defense: 2,
-            emoji: '🌊',
-            description: 'Flooded ditch adding 2 defense.'
-        },
-        Market: {
-            cost: 5,
-            coins: 2,
-            extraDraw: 1,
-            emoji: '🏪',
-            description: 'Trade hub generating coins and an extra draw.'
-        },
-        Barracks: {
-            cost: 4,
-            extraDraw: 1,
-            defense: 1,
-            emoji: '🏟️',
-            description: 'Training ground granting 1 defense and draw.'
-        },
-        Blacksmith: {
-            cost: 4,
-            coins: 1,
-            attack: 1,
-            emoji: '⚒️',
-            description: 'Forge increasing attack and coins.'
-        },
-        Chapel: {
-            cost: 3,
-            vp: 1,
-            defense: 1,
-            emoji: '⛪',
-            description: 'Place of worship offering 1 VP and defense.'
-        },
-        Stable: {
-            cost: 5,
-            coins: 2,
-            extraDraw: 1,
-            emoji: '🐴',
-            description: 'Stabling horses for coins and a draw.'
-        },
-        Infantry: {
-            cost: 3,
-            attack: 1,
-            defense: 1,
-            emoji: '🪓',
-            description: 'Foot soldier with balanced attack and defense.'
-        },
-        Catapult: {
-            cost: 6,
-            attack: 3,
-            emoji: '🪨',
-            description: 'Siege engine adding 3 attack.'
-        },
-        Trebuchet: {
-            cost: 7,
-            attack: 3,
-            defense: 1,
-            emoji: '🎯',
-            description: 'Powerful launcher with attack and defense.'
-        },
-        Merchant: {
-            cost: 4,
-            coins: 2,
-            emoji: '🛍️',
-            description: 'Travelling trader worth 2 coins.'
-        },
-        Farmer: {
-            cost: 2,
-            coins: 1,
-            defense: 1,
-            emoji: '🌾',
-            description: 'Provides food and minor defense.'
-        },
-        Baker: {
-            cost: 3,
-            coins: 1,
-            extraDraw: 1,
-            emoji: '🥖',
-            description: 'Supplies bread and 1 extra draw.'
-        },
-        Tavern: {
-            cost: 4,
-            coins: 2,
-            emoji: '🍻',
-            description: 'Gathering place yielding 2 coins.'
-        },
-        Inn: {
-            cost: 3,
-            coins: 1,
-            extraDraw: 1,
-            emoji: '🏨',
-            description: 'Resting spot for coins and a draw.'
-        },
-        Mill: {
-            cost: 4,
-            coins: 2,
-            emoji: '🌽',
-            description: 'Processes grain for 2 coins.'
-        },
-        Priest: {
-            cost: 5,
-            defense: 2,
-            vp: 1,
-            emoji: '🙏',
-            description: 'Holy man granting defense and VP.'
-        },
-        Wizard: {
-            cost: 6,
-            attack: 2,
-            extraDraw: 1,
-            emoji: '🧙',
-            description: 'Caster with attack and a draw.'
-        },
-        Alchemist: {
-            cost: 6,
-            coins: 2,
-            extraDraw: 1,
-            emoji: '⚗️',
-            description: 'Mystic who turns lead into coins and a draw.'
-        },
-        Court: {
-            cost: 5,
-            coins: 1,
-            vp: 2,
-            extraDraw: 1,
-            emoji: '🏛️',
-            description: 'Seat of power granting VP and draw.'
-        },
-        Throne: {
-            cost: 7,
-            vp: 3,
-            defense: 1,
-            emoji: '👑',
-            description: 'Symbol of rule adding VP and defense.'
-        },
-        Guardhouse: {
-            cost: 4,
-            defense: 2,
-            emoji: '🏰',
-            description: 'Fortified structure with 2 defense.'
-        },
-        Tower: {
-            cost: 6,
-            defense: 3,
-            emoji: '🗼',
-            description: 'Watchtower providing 3 defense.'
-        },
-        Wall: {
-            cost: 5,
-            defense: 3,
-            emoji: '🧱',
-            description: 'Sturdy wall worth 3 defense.'
-        },
-        Hospital: {
-            cost: 4,
-            defense: 1,
-            extraDraw: 1,
-            emoji: '🏥',
-            description: 'Heals troops and draws a card.'
-        },
-        TrainingGrounds: {
-            cost: 5,
-            attack: 1,
-            extraDraw: 1,
-            emoji: '🥋',
-            description: 'Prepares warriors with attack and draw.'
-        },
-        Mine: {
-            cost: 5,
-            coins: 2,
-            emoji: '⛏️',
-            description: 'Source of ore worth 2 coins.'
-        },
-        Quarry: {
-            cost: 4,
-            coins: 1,
-            defense: 1,
-            emoji: '🪨',
-            description: 'Stone works giving coins and defense.'
-        },
-        Explorer: {
-            cost: 4,
-            extraDraw: 2,
-            emoji: '🧭',
-            description: 'Ventures forth drawing extra cards.'
-        },
-        Ranger: {
-            cost: 5,
-            attack: 1,
-            extraDraw: 1,
-            emoji: '🏕️',
-            description: 'Watches the wilds with attack and draw.'
-        },
-        Scout: {
-            cost: 3,
-            extraDraw: 1,
-            emoji: '🕵️',
-            description: 'Provides reconnaissance and a draw.'
-        },
-        Trader: {
-            cost: 4,
-            coins: 2,
-            emoji: '💰',
-            description: 'Commercial expert worth 2 coins.'
-        },
-        Scholar: {
-            cost: 3,
-            extraDraw: 2,
-            emoji: '📚',
-            description: 'Learned figure drawing two cards.'
-        },
-        Library: {
-            cost: 6,
-            vp: 2,
-            extraDraw: 2,
-            emoji: '📖',
-            description: 'Repository of knowledge worth VP and draws.'
-        },
-        Swordsman: {
-            cost: 5,
-            attack: 2,
-            emoji: '🗡️',
-            description: 'Skilled attacker with 2 attack.'
-        },
-        Ballista: {
-            cost: 7,
-            attack: 4,
-            emoji: '🎯',
-            description: 'Deadly siege weapon with 4 attack.'
-        }
-    };
-
+document.addEventListener('DOMContentLoaded', async () => {
+    const response = await fetch('js/cards.json');
+    const cardData = await response.json();
     let deck = [];
     let discard = [];
     let hand = [];
     let coins = 0;
     let turn = 0;
     let round = 1;
+    let bonusVP = 0;
+    let aiBonusVP = 0;
     const selectedCards = new Set();
 
     // AI state
@@ -377,6 +48,23 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function getDiscount(isAi) {
+        const arr = isAi ? aiHand : hand;
+        return arr.reduce((sum, c) => sum + (cardData[c].discount || 0), 0);
+    }
+
+    function getModValue(isAi, type) {
+        const arr = isAi ? aiHand : hand;
+        let mul = 1;
+        let div = 1;
+        arr.forEach(c => {
+            const data = cardData[c];
+            if (data[type + 'Multiplier']) mul *= data[type + 'Multiplier'];
+            if (data[type + 'Divider']) div *= data[type + 'Divider'];
+        });
+        return mul / div;
+    }
+
     function draw(n) {
         for (let i = 0; i < n; i++) {
             if (deck.length === 0) {
@@ -406,6 +94,8 @@ document.addEventListener('DOMContentLoaded', () => {
         hand.forEach(c => {
             extra += cardData[c].extraDraw || 0;
         });
+        extra *= getModValue(false, 'draw');
+        extra = Math.floor(extra);
         if (extra > 0) {
             draw(extra);
         }
@@ -416,6 +106,8 @@ document.addEventListener('DOMContentLoaded', () => {
         aiHand.forEach(c => {
             extra += cardData[c].extraDraw || 0;
         });
+        extra *= getModValue(true, 'draw');
+        extra = Math.floor(extra);
         if (extra > 0) {
             aiDraw(extra);
         }
@@ -423,16 +115,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function countCoins() {
         coins = hand.reduce((sum, card) => sum + (cardData[card].coins || 0), 0);
-        const attack = aiHand.reduce((sum, card) => sum + (cardData[card].attack || 0), 0);
-        const defense = hand.reduce((sum, card) => sum + (cardData[card].defense || 0), 0);
+        coins *= getModValue(false, 'coin');
+        const attack = aiHand.reduce((sum, card) => sum + (cardData[card].attack || 0), 0) * getModValue(true, 'attack');
+        const defense = hand.reduce((sum, card) => sum + (cardData[card].defense || 0), 0) * getModValue(false, 'defense');
         coins = Math.max(0, coins - Math.max(0, attack - defense));
+        coins = Math.floor(coins);
     }
 
     function countAiCoins() {
         aiCoins = aiHand.reduce((sum, card) => sum + (cardData[card].coins || 0), 0);
-        const attack = hand.reduce((sum, card) => sum + (cardData[card].attack || 0), 0);
-        const defense = aiHand.reduce((sum, card) => sum + (cardData[card].defense || 0), 0);
+        aiCoins *= getModValue(true, 'coin');
+        const attack = hand.reduce((sum, card) => sum + (cardData[card].attack || 0), 0) * getModValue(false, 'attack');
+        const defense = aiHand.reduce((sum, card) => sum + (cardData[card].defense || 0), 0) * getModValue(true, 'defense');
         aiCoins = Math.max(0, aiCoins - Math.max(0, attack - defense));
+        aiCoins = Math.floor(aiCoins);
     }
 
     function calculateVP(arr) {
@@ -538,8 +234,8 @@ document.addEventListener('DOMContentLoaded', () => {
         aiDeckCount.textContent = aiDeck.length;
         aiDiscardCount.textContent = aiDiscard.length;
         aiCoinCount.textContent = aiCoins;
-        vpCount.textContent = calculateVP(deck) + calculateVP(discard) + calculateVP(hand);
-        aiVpCount.textContent = calculateVP(aiDeck) + calculateVP(aiDiscard) + calculateVP(aiHand);
+        vpCount.textContent = calculateVP(deck) + calculateVP(discard) + calculateVP(hand) + bonusVP;
+        aiVpCount.textContent = calculateVP(aiDeck) + calculateVP(aiDiscard) + calculateVP(aiHand) + aiBonusVP;
     }
 
     function setupMarket() {
@@ -556,6 +252,8 @@ document.addEventListener('DOMContentLoaded', () => {
         coins = 0;
         turn = 1;
         selectedCards.clear();
+        bonusVP = 0;
+        aiBonusVP = 0;
         aiDeck = [];
         aiDiscard = [];
         aiHand = [];
@@ -583,10 +281,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function buyCard(name, index) {
-        const cost = cardData[name].cost;
+        const discount = getDiscount(false);
+        const baseCost = cardData[name].cost;
+        const cost = Math.max(0, baseCost - discount);
         const available = getSelectedCoinTotal();
         if (available < cost) {
-            message.textContent = 'Not enough selected coins.';
+            message.textContent = `Not enough selected coins. Cost is ${cost}.`;
             return;
         }
 
@@ -600,6 +300,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 discard.push(hand.splice(i, 1)[0]);
             });
             discard.push(name);
+            const data = cardData[name];
+            if (data.coinOnBuy) coins += data.coinOnBuy;
+            if (data.drawOnBuy) {
+                draw(data.drawOnBuy);
+                applyExtraDraw();
+            }
+            if (data.attackOnBuy) {
+                const defense = aiHand.reduce((s,c)=>s+(cardData[c].defense||0),0) * getModValue(true,'defense');
+                const attackAmt = data.attackOnBuy * getModValue(false,'attack');
+                aiCoins = Math.max(0, aiCoins - Math.max(0, attackAmt - defense));
+            }
+            if (data.vpOnBuy) bonusVP += data.vpOnBuy;
             selectedCards.clear();
             countCoins();
             if (typeof index === 'number') {
@@ -616,12 +328,14 @@ document.addEventListener('DOMContentLoaded', () => {
     function aiTurn() {
         countAiCoins();
         let choice = null;
+        const aiDiscount = getDiscount(true);
         const options = market
-            .filter(n => cardData[n].cost <= aiCoins)
+            .filter(n => (cardData[n].cost - aiDiscount) <= aiCoins)
             .sort((a, b) => cardData[b].cost - cardData[a].cost);
         if (options.length > 0) {
             choice = options[0];
-            aiCoins -= cardData[choice].cost;
+            const finalCost = Math.max(0, cardData[choice].cost - aiDiscount);
+            aiCoins -= finalCost;
             aiDiscard.push(choice);
             const idx = market.indexOf(choice);
             if (idx !== -1) {
@@ -631,6 +345,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         aiDiscard = aiDiscard.concat(aiHand);
         aiHand = [];
+        if (choice) {
+            const data = cardData[choice];
+            if (data.coinOnBuy) aiCoins += data.coinOnBuy;
+            if (data.drawOnBuy) {
+                aiDraw(data.drawOnBuy);
+            }
+            if (data.attackOnBuy) {
+                const defense = hand.reduce((s,c)=>s+(cardData[c].defense||0),0) * getModValue(false,'defense');
+                const attackAmt = data.attackOnBuy * getModValue(true,'attack');
+                coins = Math.max(0, coins - Math.max(0, attackAmt - defense));
+            }
+            if (data.vpOnBuy) aiBonusVP += data.vpOnBuy;
+        }
         aiDraw(5);
         applyAiExtraDraw();
         countAiCoins();
@@ -640,8 +367,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function checkWin() {
-        const playerVP = calculateVP(deck) + calculateVP(discard) + calculateVP(hand);
-        const enemyVP = calculateVP(aiDeck) + calculateVP(aiDiscard) + calculateVP(aiHand);
+        const playerVP = calculateVP(deck) + calculateVP(discard) + calculateVP(hand) + bonusVP;
+        const enemyVP = calculateVP(aiDeck) + calculateVP(aiDiscard) + calculateVP(aiHand) + aiBonusVP;
         if (playerVP >= 15 || enemyVP >= 15) {
             const winner = playerVP > enemyVP ? 'You' : 'AI';
             message.textContent = `${winner} win round ${round}! Click New Game for next round.`;

--- a/js/cards.json
+++ b/js/cards.json
@@ -1,0 +1,1608 @@
+{
+    "Copper": {
+        "cost": 0,
+        "coins": 1,
+        "emoji": "🪙",
+        "description": "Basic currency worth 1 coin."
+    },
+    "Silver": {
+        "cost": 3,
+        "coins": 2,
+        "emoji": "🥈",
+        "description": "Shiny coin worth 2 coins."
+    },
+    "Gold": {
+        "cost": 6,
+        "coins": 3,
+        "emoji": "🥇",
+        "description": "Premium coin worth 3 coins."
+    },
+    "Estate": {
+        "cost": 2,
+        "vp": 1,
+        "emoji": "🏠",
+        "description": "Worth 1 victory point."
+    },
+    "Duchy": {
+        "cost": 5,
+        "vp": 3,
+        "emoji": "🏯",
+        "description": "Worth 3 victory points."
+    },
+    "Province": {
+        "cost": 9,
+        "vp": 6,
+        "emoji": "🏰",
+        "description": "Worth 6 victory points."
+    },
+    "Jester": {
+        "cost": 5,
+        "coins": 1,
+        "vp": 1,
+        "emoji": "🤹",
+        "description": "Adds 1 coin and 1 victory point with a smile."
+    },
+    "Village": {
+        "cost": 4,
+        "coins": 1,
+        "extraDraw": 1,
+        "emoji": "🏘️",
+        "description": "Gain 1 coin and draw 1 extra card each turn."
+    },
+    "Militia": {
+        "cost": 4,
+        "coins": 2,
+        "attack": 1,
+        "emoji": "⚔️",
+        "description": "Provides 2 coins and reduces your opponent's coins by 1."
+    },
+    "Squire": {
+        "cost": 3,
+        "coins": 1,
+        "defense": 1,
+        "emoji": "🛡️",
+        "description": "Provides 1 coin and 1 defense."
+    },
+    "Knight": {
+        "cost": 6,
+        "coins": 1,
+        "attack": 2,
+        "defense": 1,
+        "emoji": "🗡️",
+        "description": "Grants 1 coin, 2 attack and 1 defense."
+    },
+    "Archer": {
+        "cost": 4,
+        "attack": 1,
+        "extraDraw": 1,
+        "emoji": "🏹",
+        "description": "Provides 1 attack and draws 1 card when played."
+    },
+    "SiegeTower": {
+        "cost": 7,
+        "attack": 2,
+        "emoji": "🪜",
+        "description": "Large engine bringing 2 attack."
+    },
+    "Castle": {
+        "cost": 8,
+        "vp": 4,
+        "defense": 2,
+        "emoji": "🏰",
+        "description": "Stronghold worth 4 VP and 2 defense."
+    },
+    "Guard": {
+        "cost": 3,
+        "coins": 1,
+        "defense": 1,
+        "emoji": "🛡️",
+        "description": "Provides 1 coin and 1 defense."
+    },
+    "Moat": {
+        "cost": 2,
+        "defense": 2,
+        "emoji": "🌊",
+        "description": "Flooded ditch adding 2 defense."
+    },
+    "Market": {
+        "cost": 5,
+        "coins": 2,
+        "extraDraw": 1,
+        "emoji": "🏪",
+        "description": "Generates 2 coins and lets you draw 1 extra card."
+    },
+    "Barracks": {
+        "cost": 4,
+        "extraDraw": 1,
+        "defense": 1,
+        "emoji": "🏟️",
+        "description": "Grants 1 defense and lets you draw 1 extra card."
+    },
+    "Blacksmith": {
+        "cost": 4,
+        "coins": 1,
+        "attack": 1,
+        "emoji": "⚒️",
+        "description": "Adds 1 coin and 1 attack."
+    },
+    "Chapel": {
+        "cost": 3,
+        "vp": 1,
+        "defense": 1,
+        "emoji": "⛪",
+        "description": "Provides 1 victory point and 1 defense."
+    },
+    "Stable": {
+        "cost": 5,
+        "coins": 2,
+        "extraDraw": 1,
+        "emoji": "🐴",
+        "description": "Gain 2 coins and draw 1 extra card."
+    },
+    "Infantry": {
+        "cost": 3,
+        "attack": 1,
+        "defense": 1,
+        "emoji": "🪓",
+        "description": "Provides 1 attack and 1 defense."
+    },
+    "Catapult": {
+        "cost": 6,
+        "attack": 3,
+        "emoji": "🪨",
+        "description": "Siege engine adding 3 attack."
+    },
+    "Trebuchet": {
+        "cost": 7,
+        "attack": 3,
+        "defense": 1,
+        "emoji": "🎯",
+        "description": "Adds 3 attack and 1 defense."
+    },
+    "Merchant": {
+        "cost": 4,
+        "coins": 2,
+        "emoji": "🛍️",
+        "description": "Travelling trader worth 2 coins."
+    },
+    "Farmer": {
+        "cost": 2,
+        "coins": 1,
+        "defense": 1,
+        "emoji": "🌾",
+        "description": "Provides 1 coin and 1 defense."
+    },
+    "Baker": {
+        "cost": 3,
+        "coins": 1,
+        "extraDraw": 1,
+        "emoji": "🥖",
+        "description": "Provides 1 coin and draws 1 extra card."
+    },
+    "Tavern": {
+        "cost": 4,
+        "coins": 2,
+        "emoji": "🍻",
+        "description": "Gathering place yielding 2 coins."
+    },
+    "Inn": {
+        "cost": 3,
+        "coins": 1,
+        "extraDraw": 1,
+        "emoji": "🏨",
+        "description": "Gain 1 coin and draw 1 extra card."
+    },
+    "Mill": {
+        "cost": 4,
+        "coins": 2,
+        "emoji": "🌽",
+        "description": "Processes grain for 2 coins."
+    },
+    "Priest": {
+        "cost": 5,
+        "defense": 2,
+        "vp": 1,
+        "emoji": "🙏",
+        "description": "Grants 2 defense and 1 victory point."
+    },
+    "Wizard": {
+        "cost": 6,
+        "attack": 2,
+        "extraDraw": 1,
+        "emoji": "🧙",
+        "description": "Adds 2 attack and lets you draw 1 extra card."
+    },
+    "Alchemist": {
+        "cost": 6,
+        "coins": 2,
+        "extraDraw": 1,
+        "emoji": "⚗️",
+        "description": "Gives 2 coins and lets you draw 1 extra card."
+    },
+    "Court": {
+        "cost": 5,
+        "coins": 1,
+        "vp": 2,
+        "extraDraw": 1,
+        "emoji": "🏛️",
+        "description": "Provides 1 coin, 2 victory points and draws 1 card."
+    },
+    "Throne": {
+        "cost": 7,
+        "vp": 3,
+        "defense": 1,
+        "emoji": "👑",
+        "description": "Adds 3 victory points and 1 defense."
+    },
+    "Guardhouse": {
+        "cost": 4,
+        "defense": 2,
+        "emoji": "🏰",
+        "description": "Fortified structure with 2 defense."
+    },
+    "Tower": {
+        "cost": 6,
+        "defense": 3,
+        "emoji": "🗼",
+        "description": "Watchtower providing 3 defense."
+    },
+    "Wall": {
+        "cost": 5,
+        "defense": 3,
+        "emoji": "🧱",
+        "description": "Sturdy wall worth 3 defense."
+    },
+    "Hospital": {
+        "cost": 4,
+        "defense": 1,
+        "extraDraw": 1,
+        "emoji": "🏥",
+        "description": "Provides 1 defense and lets you draw 1 card."
+    },
+    "TrainingGrounds": {
+        "cost": 5,
+        "attack": 1,
+        "extraDraw": 1,
+        "emoji": "🥋",
+        "description": "Adds 1 attack and lets you draw 1 card."
+    },
+    "Mine": {
+        "cost": 5,
+        "coins": 2,
+        "emoji": "⛏️",
+        "description": "Source of ore worth 2 coins."
+    },
+    "Quarry": {
+        "cost": 4,
+        "coins": 1,
+        "defense": 1,
+        "emoji": "🪨",
+        "description": "Provides 1 coin and 1 defense."
+    },
+    "Explorer": {
+        "cost": 4,
+        "extraDraw": 2,
+        "emoji": "🧭",
+        "description": "Draw 2 additional cards."
+    },
+    "Ranger": {
+        "cost": 5,
+        "attack": 1,
+        "extraDraw": 1,
+        "emoji": "🏕️",
+        "description": "Adds 1 attack and draws 1 extra card."
+    },
+    "Scout": {
+        "cost": 3,
+        "extraDraw": 1,
+        "emoji": "🕵️",
+        "description": "Draw 1 extra card while scouting."
+    },
+    "Trader": {
+        "cost": 4,
+        "coins": 2,
+        "emoji": "💰",
+        "description": "Commercial expert worth 2 coins."
+    },
+    "Scholar": {
+        "cost": 3,
+        "extraDraw": 2,
+        "emoji": "📚",
+        "description": "Draw 2 cards thanks to scholarly study."
+    },
+    "Library": {
+        "cost": 6,
+        "vp": 2,
+        "extraDraw": 2,
+        "emoji": "📖",
+        "description": "Worth 2 victory points and draws 2 cards."
+    },
+    "Swordsman": {
+        "cost": 5,
+        "attack": 2,
+        "emoji": "🗡️",
+        "description": "Skilled attacker with 2 attack."
+    },
+    "Ballista": {
+        "cost": 7,
+        "attack": 4,
+        "emoji": "🎯",
+        "description": "Deadly siege weapon with 4 attack."
+    },
+    "MerchantGuild": {
+        "cost": 4,
+        "discount": 3,
+        "emoji": "🤝",
+        "description": "MerchantGuild lowers future purchases by 3."
+    },
+    "ScribesGuild": {
+        "cost": 3,
+        "discount": 3,
+        "emoji": "🤝",
+        "description": "ScribesGuild lowers future purchases by 3."
+    },
+    "HuntersGuild": {
+        "cost": 6,
+        "discount": 4,
+        "emoji": "🤝",
+        "description": "HuntersGuild lowers future purchases by 4."
+    },
+    "ThievesGuild": {
+        "cost": 6,
+        "discount": 4,
+        "emoji": "🤝",
+        "description": "ThievesGuild lowers future purchases by 4."
+    },
+    "BuildersGuild": {
+        "cost": 4,
+        "discount": 1,
+        "emoji": "🤝",
+        "description": "BuildersGuild lowers future purchases by 1."
+    },
+    "MasonsGuild": {
+        "cost": 6,
+        "discount": 3,
+        "emoji": "🤝",
+        "description": "MasonsGuild lowers future purchases by 3."
+    },
+    "ArtisansGuild": {
+        "cost": 6,
+        "discount": 2,
+        "emoji": "🤝",
+        "description": "ArtisansGuild lowers future purchases by 2."
+    },
+    "BakersGuild": {
+        "cost": 3,
+        "discount": 1,
+        "emoji": "🤝",
+        "description": "BakersGuild lowers future purchases by 1."
+    },
+    "AlchemistsGuild": {
+        "cost": 6,
+        "discount": 1,
+        "emoji": "🤝",
+        "description": "AlchemistsGuild lowers future purchases by 1."
+    },
+    "NavigatorsGuild": {
+        "cost": 5,
+        "discount": 2,
+        "emoji": "🤝",
+        "description": "NavigatorsGuild lowers future purchases by 2."
+    },
+    "BlacksmithsGuild": {
+        "cost": 5,
+        "discount": 1,
+        "emoji": "🤝",
+        "description": "BlacksmithsGuild lowers future purchases by 1."
+    },
+    "CartographersGuild": {
+        "cost": 6,
+        "discount": 5,
+        "emoji": "🤝",
+        "description": "CartographersGuild lowers future purchases by 5."
+    },
+    "MercenariesGuild": {
+        "cost": 6,
+        "discount": 5,
+        "emoji": "🤝",
+        "description": "MercenariesGuild lowers future purchases by 5."
+    },
+    "HerbalistsGuild": {
+        "cost": 4,
+        "discount": 4,
+        "emoji": "🤝",
+        "description": "HerbalistsGuild lowers future purchases by 4."
+    },
+    "ArmorsmithsGuild": {
+        "cost": 5,
+        "discount": 5,
+        "emoji": "🤝",
+        "description": "ArmorsmithsGuild lowers future purchases by 5."
+    },
+    "JewelersGuild": {
+        "cost": 5,
+        "discount": 1,
+        "emoji": "🤝",
+        "description": "JewelersGuild lowers future purchases by 1."
+    },
+    "TailorsGuild": {
+        "cost": 5,
+        "discount": 5,
+        "emoji": "🤝",
+        "description": "TailorsGuild lowers future purchases by 5."
+    },
+    "SculptorsGuild": {
+        "cost": 5,
+        "discount": 3,
+        "emoji": "🤝",
+        "description": "SculptorsGuild lowers future purchases by 3."
+    },
+    "BrewersGuild": {
+        "cost": 4,
+        "discount": 1,
+        "emoji": "🤝",
+        "description": "BrewersGuild lowers future purchases by 1."
+    },
+    "InventorsGuild": {
+        "cost": 5,
+        "discount": 2,
+        "emoji": "🤝",
+        "description": "InventorsGuild lowers future purchases by 2."
+    },
+    "GoldenCaravan": {
+        "cost": 5,
+        "coinOnBuy": 3,
+        "emoji": "🐪",
+        "description": "GoldenCaravan grants 3 coins on buy."
+    },
+    "SpiceCaravan": {
+        "cost": 5,
+        "coinOnBuy": 1,
+        "emoji": "🐪",
+        "description": "SpiceCaravan grants 1 coin on buy."
+    },
+    "SilkCaravan": {
+        "cost": 4,
+        "coinOnBuy": 4,
+        "emoji": "🐪",
+        "description": "SilkCaravan grants 4 coins on buy."
+    },
+    "OreCaravan": {
+        "cost": 5,
+        "coinOnBuy": 2,
+        "emoji": "🐪",
+        "description": "OreCaravan grants 2 coins on buy."
+    },
+    "GrainCaravan": {
+        "cost": 5,
+        "coinOnBuy": 2,
+        "emoji": "🐪",
+        "description": "GrainCaravan grants 2 coins on buy."
+    },
+    "DesertCaravan": {
+        "cost": 7,
+        "coinOnBuy": 1,
+        "emoji": "🐪",
+        "description": "DesertCaravan grants 1 coin on buy."
+    },
+    "NorthernCaravan": {
+        "cost": 4,
+        "coinOnBuy": 3,
+        "emoji": "🐪",
+        "description": "NorthernCaravan grants 3 coins on buy."
+    },
+    "MerchantCaravan": {
+        "cost": 4,
+        "coinOnBuy": 1,
+        "emoji": "🐪",
+        "description": "MerchantCaravan grants 1 coin on buy."
+    },
+    "CargoCaravan": {
+        "cost": 4,
+        "coinOnBuy": 1,
+        "emoji": "🐪",
+        "description": "CargoCaravan grants 1 coin on buy."
+    },
+    "RoyalCaravan": {
+        "cost": 6,
+        "coinOnBuy": 5,
+        "emoji": "🐪",
+        "description": "RoyalCaravan grants 5 coins on buy."
+    },
+    "HiddenCaravan": {
+        "cost": 6,
+        "coinOnBuy": 5,
+        "emoji": "🐪",
+        "description": "HiddenCaravan grants 5 coins on buy."
+    },
+    "RiverCaravan": {
+        "cost": 6,
+        "coinOnBuy": 1,
+        "emoji": "🐪",
+        "description": "RiverCaravan grants 1 coin on buy."
+    },
+    "OceanCaravan": {
+        "cost": 5,
+        "coinOnBuy": 4,
+        "emoji": "🐪",
+        "description": "OceanCaravan grants 4 coins on buy."
+    },
+    "GemCaravan": {
+        "cost": 5,
+        "coinOnBuy": 3,
+        "emoji": "🐪",
+        "description": "GemCaravan grants 3 coins on buy."
+    },
+    "TimberCaravan": {
+        "cost": 4,
+        "coinOnBuy": 1,
+        "emoji": "🐪",
+        "description": "TimberCaravan grants 1 coin on buy."
+    },
+    "WineCaravan": {
+        "cost": 7,
+        "coinOnBuy": 5,
+        "emoji": "🐪",
+        "description": "WineCaravan grants 5 coins on buy."
+    },
+    "BattleCaravan": {
+        "cost": 7,
+        "coinOnBuy": 3,
+        "emoji": "🐪",
+        "description": "BattleCaravan grants 3 coins on buy."
+    },
+    "AdventurersCaravan": {
+        "cost": 4,
+        "coinOnBuy": 4,
+        "emoji": "🐪",
+        "description": "AdventurersCaravan grants 4 coins on buy."
+    },
+    "LanternCaravan": {
+        "cost": 4,
+        "coinOnBuy": 3,
+        "emoji": "🐪",
+        "description": "LanternCaravan grants 3 coins on buy."
+    },
+    "ShadowCaravan": {
+        "cost": 5,
+        "coinOnBuy": 1,
+        "emoji": "🐪",
+        "description": "ShadowCaravan grants 1 coin on buy."
+    },
+    "WiseInsight": {
+        "cost": 6,
+        "drawOnBuy": 3,
+        "emoji": "💡",
+        "description": "Buying WiseInsight draws 3 cards."
+    },
+    "DeepThought": {
+        "cost": 6,
+        "drawOnBuy": 5,
+        "emoji": "💡",
+        "description": "Buying DeepThought draws 5 cards."
+    },
+    "MysticVision": {
+        "cost": 7,
+        "drawOnBuy": 2,
+        "emoji": "💡",
+        "description": "Buying MysticVision draws 2 cards."
+    },
+    "ForesightScroll": {
+        "cost": 6,
+        "drawOnBuy": 2,
+        "emoji": "💡",
+        "description": "Buying ForesightScroll draws 2 cards."
+    },
+    "SageAdvice": {
+        "cost": 6,
+        "drawOnBuy": 1,
+        "emoji": "💡",
+        "description": "Buying SageAdvice draws 1 card."
+    },
+    "Prophecy": {
+        "cost": 6,
+        "drawOnBuy": 3,
+        "emoji": "💡",
+        "description": "Buying Prophecy draws 3 cards."
+    },
+    "BattlePlan": {
+        "cost": 4,
+        "drawOnBuy": 3,
+        "emoji": "💡",
+        "description": "Buying BattlePlan draws 3 cards."
+    },
+    "SecretMap": {
+        "cost": 7,
+        "drawOnBuy": 5,
+        "emoji": "💡",
+        "description": "Buying SecretMap draws 5 cards."
+    },
+    "FutureGlance": {
+        "cost": 6,
+        "drawOnBuy": 1,
+        "emoji": "💡",
+        "description": "Buying FutureGlance draws 1 card."
+    },
+    "ScholarsNotes": {
+        "cost": 6,
+        "drawOnBuy": 1,
+        "emoji": "💡",
+        "description": "Buying ScholarsNotes draws 1 card."
+    },
+    "TacticalGuide": {
+        "cost": 5,
+        "drawOnBuy": 3,
+        "emoji": "💡",
+        "description": "Buying TacticalGuide draws 3 cards."
+    },
+    "EnchantedLibrary": {
+        "cost": 6,
+        "drawOnBuy": 5,
+        "emoji": "💡",
+        "description": "Buying EnchantedLibrary draws 5 cards."
+    },
+    "SeersStone": {
+        "cost": 6,
+        "drawOnBuy": 1,
+        "emoji": "💡",
+        "description": "Buying SeersStone draws 1 card."
+    },
+    "HolyRevelation": {
+        "cost": 4,
+        "drawOnBuy": 5,
+        "emoji": "💡",
+        "description": "Buying HolyRevelation draws 5 cards."
+    },
+    "ArcaneWisdom": {
+        "cost": 6,
+        "drawOnBuy": 3,
+        "emoji": "💡",
+        "description": "Buying ArcaneWisdom draws 3 cards."
+    },
+    "InspiredStrategy": {
+        "cost": 5,
+        "drawOnBuy": 4,
+        "emoji": "💡",
+        "description": "Buying InspiredStrategy draws 4 cards."
+    },
+    "DreamWhisper": {
+        "cost": 5,
+        "drawOnBuy": 1,
+        "emoji": "💡",
+        "description": "Buying DreamWhisper draws 1 card."
+    },
+    "PastLessons": {
+        "cost": 6,
+        "drawOnBuy": 1,
+        "emoji": "💡",
+        "description": "Buying PastLessons draws 1 card."
+    },
+    "HiddenTruth": {
+        "cost": 6,
+        "drawOnBuy": 1,
+        "emoji": "💡",
+        "description": "Buying HiddenTruth draws 1 card."
+    },
+    "DruidicRite": {
+        "cost": 7,
+        "drawOnBuy": 4,
+        "emoji": "💡",
+        "description": "Buying DruidicRite draws 4 cards."
+    },
+    "SwiftRaid": {
+        "cost": 6,
+        "attackOnBuy": 4,
+        "emoji": "🔥",
+        "description": "SwiftRaid removes 4 coins from the opponent when bought."
+    },
+    "BrutalRaid": {
+        "cost": 5,
+        "attackOnBuy": 1,
+        "emoji": "🔥",
+        "description": "BrutalRaid removes 1 coin from the opponent when bought."
+    },
+    "NightRaid": {
+        "cost": 8,
+        "attackOnBuy": 3,
+        "emoji": "🔥",
+        "description": "NightRaid removes 3 coins from the opponent when bought."
+    },
+    "CoastalRaid": {
+        "cost": 5,
+        "attackOnBuy": 5,
+        "emoji": "🔥",
+        "description": "CoastalRaid removes 5 coins from the opponent when bought."
+    },
+    "SiegeRaid": {
+        "cost": 8,
+        "attackOnBuy": 2,
+        "emoji": "🔥",
+        "description": "SiegeRaid removes 2 coins from the opponent when bought."
+    },
+    "SkirmishRaid": {
+        "cost": 5,
+        "attackOnBuy": 3,
+        "emoji": "🔥",
+        "description": "SkirmishRaid removes 3 coins from the opponent when bought."
+    },
+    "AmbushRaid": {
+        "cost": 6,
+        "attackOnBuy": 2,
+        "emoji": "🔥",
+        "description": "AmbushRaid removes 2 coins from the opponent when bought."
+    },
+    "SurpriseRaid": {
+        "cost": 5,
+        "attackOnBuy": 4,
+        "emoji": "🔥",
+        "description": "SurpriseRaid removes 4 coins from the opponent when bought."
+    },
+    "SavageRaid": {
+        "cost": 5,
+        "attackOnBuy": 4,
+        "emoji": "🔥",
+        "description": "SavageRaid removes 4 coins from the opponent when bought."
+    },
+    "BorderRaid": {
+        "cost": 8,
+        "attackOnBuy": 2,
+        "emoji": "🔥",
+        "description": "BorderRaid removes 2 coins from the opponent when bought."
+    },
+    "PillageRaid": {
+        "cost": 5,
+        "attackOnBuy": 4,
+        "emoji": "🔥",
+        "description": "PillageRaid removes 4 coins from the opponent when bought."
+    },
+    "BurningRaid": {
+        "cost": 8,
+        "attackOnBuy": 5,
+        "emoji": "🔥",
+        "description": "BurningRaid removes 5 coins from the opponent when bought."
+    },
+    "RagingRaid": {
+        "cost": 6,
+        "attackOnBuy": 4,
+        "emoji": "🔥",
+        "description": "RagingRaid removes 4 coins from the opponent when bought."
+    },
+    "FierceRaid": {
+        "cost": 6,
+        "attackOnBuy": 1,
+        "emoji": "🔥",
+        "description": "FierceRaid removes 1 coin from the opponent when bought."
+    },
+    "RecklessRaid": {
+        "cost": 7,
+        "attackOnBuy": 1,
+        "emoji": "🔥",
+        "description": "RecklessRaid removes 1 coin from the opponent when bought."
+    },
+    "StealthRaid": {
+        "cost": 8,
+        "attackOnBuy": 5,
+        "emoji": "🔥",
+        "description": "StealthRaid removes 5 coins from the opponent when bought."
+    },
+    "FuriousRaid": {
+        "cost": 8,
+        "attackOnBuy": 5,
+        "emoji": "🔥",
+        "description": "FuriousRaid removes 5 coins from the opponent when bought."
+    },
+    "MountainRaid": {
+        "cost": 7,
+        "attackOnBuy": 4,
+        "emoji": "🔥",
+        "description": "MountainRaid removes 4 coins from the opponent when bought."
+    },
+    "HighwayRaid": {
+        "cost": 5,
+        "attackOnBuy": 2,
+        "emoji": "🔥",
+        "description": "HighwayRaid removes 2 coins from the opponent when bought."
+    },
+    "FinalRaid": {
+        "cost": 8,
+        "attackOnBuy": 3,
+        "emoji": "🔥",
+        "description": "FinalRaid removes 3 coins from the opponent when bought."
+    },
+    "StoneMonument": {
+        "cost": 8,
+        "vpOnBuy": 2,
+        "emoji": "🗿",
+        "description": "StoneMonument awards 2 victory points on buy."
+    },
+    "GrandMonument": {
+        "cost": 7,
+        "vpOnBuy": 5,
+        "emoji": "🗿",
+        "description": "GrandMonument awards 5 victory points on buy."
+    },
+    "HeroMonument": {
+        "cost": 8,
+        "vpOnBuy": 2,
+        "emoji": "🗿",
+        "description": "HeroMonument awards 2 victory points on buy."
+    },
+    "EternalMonument": {
+        "cost": 5,
+        "vpOnBuy": 1,
+        "emoji": "🗿",
+        "description": "EternalMonument awards 1 victory point on buy."
+    },
+    "VictoryMonument": {
+        "cost": 5,
+        "vpOnBuy": 2,
+        "emoji": "🗿",
+        "description": "VictoryMonument awards 2 victory points on buy."
+    },
+    "KingsMonument": {
+        "cost": 7,
+        "vpOnBuy": 3,
+        "emoji": "🗿",
+        "description": "KingsMonument awards 3 victory points on buy."
+    },
+    "WarriorMonument": {
+        "cost": 6,
+        "vpOnBuy": 3,
+        "emoji": "🗿",
+        "description": "WarriorMonument awards 3 victory points on buy."
+    },
+    "GuardianMonument": {
+        "cost": 8,
+        "vpOnBuy": 4,
+        "emoji": "🗿",
+        "description": "GuardianMonument awards 4 victory points on buy."
+    },
+    "ScholarMonument": {
+        "cost": 8,
+        "vpOnBuy": 3,
+        "emoji": "🗿",
+        "description": "ScholarMonument awards 3 victory points on buy."
+    },
+    "AngelMonument": {
+        "cost": 5,
+        "vpOnBuy": 2,
+        "emoji": "🗿",
+        "description": "AngelMonument awards 2 victory points on buy."
+    },
+    "NavigatorMonument": {
+        "cost": 8,
+        "vpOnBuy": 1,
+        "emoji": "🗿",
+        "description": "NavigatorMonument awards 1 victory point on buy."
+    },
+    "SunMonument": {
+        "cost": 5,
+        "vpOnBuy": 1,
+        "emoji": "🗿",
+        "description": "SunMonument awards 1 victory point on buy."
+    },
+    "MoonMonument": {
+        "cost": 7,
+        "vpOnBuy": 4,
+        "emoji": "🗿",
+        "description": "MoonMonument awards 4 victory points on buy."
+    },
+    "DragonMonument": {
+        "cost": 8,
+        "vpOnBuy": 4,
+        "emoji": "🗿",
+        "description": "DragonMonument awards 4 victory points on buy."
+    },
+    "PhoenixMonument": {
+        "cost": 8,
+        "vpOnBuy": 4,
+        "emoji": "🗿",
+        "description": "PhoenixMonument awards 4 victory points on buy."
+    },
+    "WarMonument": {
+        "cost": 5,
+        "vpOnBuy": 2,
+        "emoji": "🗿",
+        "description": "WarMonument awards 2 victory points on buy."
+    },
+    "ProsperityMonument": {
+        "cost": 8,
+        "vpOnBuy": 5,
+        "emoji": "🗿",
+        "description": "ProsperityMonument awards 5 victory points on buy."
+    },
+    "TriumphMonument": {
+        "cost": 6,
+        "vpOnBuy": 3,
+        "emoji": "🗿",
+        "description": "TriumphMonument awards 3 victory points on buy."
+    },
+    "HopeMonument": {
+        "cost": 6,
+        "vpOnBuy": 3,
+        "emoji": "🗿",
+        "description": "HopeMonument awards 3 victory points on buy."
+    },
+    "UnityMonument": {
+        "cost": 5,
+        "vpOnBuy": 3,
+        "emoji": "🗿",
+        "description": "UnityMonument awards 3 victory points on buy."
+    },
+    "CoinDoubler": {
+        "cost": 5,
+        "coinMultiplier": 2,
+        "emoji": "✖️",
+        "description": "CoinDoubler multiplies your coin total by 2."
+    },
+    "CoinHalver": {
+        "cost": 2,
+        "coinDivider": 2,
+        "emoji": "➗",
+        "description": "CoinHalver divides your coin total by 2."
+    },
+    "DrawDoubler": {
+        "cost": 4,
+        "drawMultiplier": 2,
+        "emoji": "🎴",
+        "description": "DrawDoubler doubles your extra draw effects."
+    },
+    "DrawHalver": {
+        "cost": 3,
+        "drawDivider": 2,
+        "emoji": "🃏",
+        "description": "DrawHalver halves your extra draw effects."
+    },
+    "AttackDoubler": {
+        "cost": 6,
+        "attackMultiplier": 2,
+        "emoji": "💥",
+        "description": "AttackDoubler doubles attack values."
+    },
+    "AttackHalver": {
+        "cost": 4,
+        "attackDivider": 2,
+        "emoji": "✝️",
+        "description": "AttackHalver halves attack values."
+    },
+    "DefenseDoubler": {
+        "cost": 6,
+        "defenseMultiplier": 2,
+        "emoji": "🛡️",
+        "description": "DefenseDoubler doubles defense values."
+    },
+    "DefenseHalver": {
+        "cost": 4,
+        "defenseDivider": 2,
+        "emoji": "🥀",
+        "description": "DefenseHalver halves defense values."
+    },
+    "Herbalist": {
+        "cost": 5,
+        "attack": 2,
+        "defense": 1,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Adds 2 attack and provides 1 defense and draws 1 card and worth 1 VP."
+    },
+    "Fletcher": {
+        "cost": 6,
+        "coins": 2,
+        "attack": 1,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and provides 2 defense and draws 2 cards and worth 1 VP."
+    },
+    "Pikeman": {
+        "cost": 3,
+        "coins": 1,
+        "attack": 2,
+        "defense": 2,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 2 defense and draws 1 card."
+    },
+    "Herald": {
+        "cost": 2,
+        "coins": 1,
+        "attack": 1,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and draws 2 cards and worth 1 VP."
+    },
+    "Bard": {
+        "cost": 4,
+        "coins": 2,
+        "attack": 1,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and draws 1 card and worth 1 VP."
+    },
+    "Carpenter": {
+        "cost": 2,
+        "coins": 1,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and provides 1 defense and draws 1 card."
+    },
+    "Butcher": {
+        "cost": 4,
+        "coins": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and worth 2 VP."
+    },
+    "Fishmonger": {
+        "cost": 3,
+        "coins": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and worth 1 VP."
+    },
+    "Shepherd": {
+        "cost": 5,
+        "attack": 2,
+        "defense": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Adds 2 attack and provides 2 defense and worth 1 VP."
+    },
+    "Apprentice": {
+        "cost": 2,
+        "coins": 1,
+        "attack": 1,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and draws 2 cards."
+    },
+    "Barbarian": {
+        "cost": 3,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Adds 1 attack and provides 1 defense and draws 1 card and worth 2 VP."
+    },
+    "MerchantShip": {
+        "cost": 6,
+        "coins": 1,
+        "attack": 2,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 2 defense and draws 2 cards and worth 1 VP."
+    },
+    "Sailor": {
+        "cost": 5,
+        "coins": 1,
+        "defense": 2,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and provides 2 defense and draws 1 card and worth 1 VP."
+    },
+    "Navigator": {
+        "cost": 7,
+        "defense": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Provides 1 defense and worth 1 VP."
+    },
+    "Cartwright": {
+        "cost": 6,
+        "coins": 2,
+        "attack": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and worth 2 VP."
+    },
+    "Mason": {
+        "cost": 4,
+        "coins": 1,
+        "attack": 2,
+        "defense": 2,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 2 defense and draws 1 card and worth 2 VP."
+    },
+    "Tanner": {
+        "cost": 4,
+        "coins": 2,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and provides 1 defense and draws 2 cards and worth 2 VP."
+    },
+    "Weaver": {
+        "cost": 4,
+        "coins": 2,
+        "attack": 2,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 2 attack and draws 1 card and worth 2 VP."
+    },
+    "Glassblower": {
+        "cost": 6,
+        "attack": 2,
+        "emoji": "",
+        "description": "Adds 2 attack."
+    },
+    "Potter": {
+        "cost": 6,
+        "coins": 1,
+        "attack": 1,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and provides 2 defense and draws 2 cards and worth 1 VP."
+    },
+    "Candlemaker": {
+        "cost": 7,
+        "defense": 1,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Provides 1 defense and draws 1 card and worth 2 VP."
+    },
+    "CharcoalBurner": {
+        "cost": 4,
+        "coins": 1,
+        "attack": 2,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and draws 1 card and worth 2 VP."
+    },
+    "Messenger": {
+        "cost": 5,
+        "coins": 1,
+        "attack": 1,
+        "defense": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and provides 2 defense."
+    },
+    "Courier": {
+        "cost": 4,
+        "coins": 2,
+        "defense": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and provides 1 defense and worth 1 VP."
+    },
+    "Postmaster": {
+        "cost": 3,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Draws 2 cards."
+    },
+    "Innkeeper": {
+        "cost": 4,
+        "coins": 1,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and draws 1 card."
+    },
+    "Bowman": {
+        "cost": 3,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Provides 2 defense and draws 2 cards and worth 2 VP."
+    },
+    "Crossbowman": {
+        "cost": 7,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Draws 1 card and worth 1 VP."
+    },
+    "Spearman": {
+        "cost": 5,
+        "coins": 1,
+        "attack": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and worth 2 VP."
+    },
+    "Axeman": {
+        "cost": 5,
+        "attack": 2,
+        "defense": 1,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Adds 2 attack and provides 1 defense and draws 1 card."
+    },
+    "Maceman": {
+        "cost": 2,
+        "coins": 1,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and provides 1 defense and draws 2 cards."
+    },
+    "Piper": {
+        "cost": 5,
+        "coins": 1,
+        "attack": 2,
+        "defense": 1,
+        "extraDraw": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 1 defense and draws 2 cards and worth 2 VP."
+    },
+    "HerbalistApprentice": {
+        "cost": 4,
+        "defense": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Provides 1 defense and worth 1 VP."
+    },
+    "Seer": {
+        "cost": 6,
+        "coins": 1,
+        "attack": 2,
+        "defense": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 2 defense and worth 2 VP."
+    },
+    "Oracle": {
+        "cost": 2,
+        "coins": 2,
+        "attack": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and worth 2 VP."
+    },
+    "Illusionist": {
+        "cost": 5,
+        "coins": 1,
+        "attack": 2,
+        "defense": 1,
+        "extraDraw": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 1 defense and draws 2 cards and worth 2 VP."
+    },
+    "Scribe": {
+        "cost": 5,
+        "coins": 2,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and provides 1 defense and draws 1 card."
+    },
+    "Page": {
+        "cost": 4,
+        "coins": 1,
+        "attack": 1,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and draws 2 cards and worth 1 VP."
+    },
+    "SailorCaptain": {
+        "cost": 4,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Adds 1 attack and provides 1 defense and draws 1 card and worth 1 VP."
+    },
+    "Almoner": {
+        "cost": 5,
+        "coins": 2,
+        "defense": 2,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and provides 2 defense and draws 1 card and worth 1 VP."
+    },
+    "Bishop": {
+        "cost": 7,
+        "coins": 1,
+        "attack": 2,
+        "defense": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 1 defense and worth 1 VP."
+    },
+    "Chaplain": {
+        "cost": 7,
+        "coins": 2,
+        "attack": 1,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and draws 2 cards and worth 1 VP."
+    },
+    "Friar": {
+        "cost": 6,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Draws 2 cards and worth 1 VP."
+    },
+    "Monk": {
+        "cost": 5,
+        "coins": 2,
+        "attack": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and worth 2 VP."
+    },
+    "Heretic": {
+        "cost": 5,
+        "coins": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and worth 2 VP."
+    },
+    "Nomad": {
+        "cost": 7,
+        "coins": 1,
+        "attack": 2,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and draws 1 card and worth 2 VP."
+    },
+    "Gypsy": {
+        "cost": 2,
+        "coins": 1,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and provides 2 defense and draws 2 cards and worth 2 VP."
+    },
+    "Minstrel": {
+        "cost": 4,
+        "attack": 1,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Adds 1 attack and draws 1 card."
+    },
+    "Troubadour": {
+        "cost": 2,
+        "coins": 1,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and provides 1 defense and draws 2 cards and worth 1 VP."
+    },
+    "Lancer": {
+        "cost": 3,
+        "attack": 2,
+        "defense": 1,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Adds 2 attack and provides 1 defense and draws 1 card and worth 1 VP."
+    },
+    "FlagBearer": {
+        "cost": 2,
+        "coins": 1,
+        "attack": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and worth 2 VP."
+    },
+    "Watchman": {
+        "cost": 7,
+        "coins": 2,
+        "attack": 2,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 2 attack and provides 2 defense and draws 2 cards and worth 1 VP."
+    },
+    "Lookout": {
+        "cost": 3,
+        "coins": 2,
+        "attack": 1,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and draws 1 card and worth 2 VP."
+    },
+    "CourierPigeon": {
+        "cost": 4,
+        "attack": 2,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Adds 2 attack and provides 2 defense and draws 2 cards and worth 1 VP."
+    },
+    "Wayfarer": {
+        "cost": 4,
+        "coins": 2,
+        "attack": 2,
+        "defense": 2,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 2 attack and provides 2 defense and draws 2 cards."
+    },
+    "Pilgrim": {
+        "cost": 5,
+        "attack": 1,
+        "defense": 2,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Adds 1 attack and provides 2 defense and draws 2 cards."
+    },
+    "Poet": {
+        "cost": 3,
+        "coins": 2,
+        "attack": 1,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and draws 1 card and worth 1 VP."
+    },
+    "Historian": {
+        "cost": 4,
+        "coins": 2,
+        "attack": 1,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and draws 2 cards and worth 1 VP."
+    },
+    "Seamstress": {
+        "cost": 6,
+        "coins": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and worth 2 VP."
+    },
+    "Librarian": {
+        "cost": 4,
+        "coins": 2,
+        "defense": 2,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and provides 2 defense and draws 1 card."
+    },
+    "Archivist": {
+        "cost": 6,
+        "attack": 1,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Adds 1 attack and draws 2 cards."
+    },
+    "Gatekeeper": {
+        "cost": 2,
+        "coins": 2,
+        "attack": 2,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 2 attack and draws 2 cards."
+    },
+    "Sentinel": {
+        "cost": 5,
+        "defense": 2,
+        "extraDraw": 1,
+        "emoji": "",
+        "description": "Provides 2 defense and draws 1 card."
+    },
+    "Horseman": {
+        "cost": 6,
+        "coins": 1,
+        "attack": 2,
+        "defense": 1,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 2 attack and provides 1 defense and draws 2 cards."
+    },
+    "Duelist": {
+        "cost": 3,
+        "coins": 2,
+        "attack": 2,
+        "defense": 1,
+        "extraDraw": 2,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 2 attack and provides 1 defense and draws 2 cards."
+    },
+    "Harpooner": {
+        "cost": 6,
+        "coins": 2,
+        "attack": 2,
+        "defense": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 2 attack and provides 2 defense and worth 1 VP."
+    },
+    "Fisherman": {
+        "cost": 2,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Adds 1 attack and provides 1 defense and draws 2 cards and worth 2 VP."
+    },
+    "Shipwright": {
+        "cost": 2,
+        "coins": 2,
+        "attack": 2,
+        "defense": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 2 attack and provides 2 defense and worth 1 VP."
+    },
+    "NavigatorCaptain": {
+        "cost": 4,
+        "coins": 1,
+        "defense": 1,
+        "extraDraw": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and provides 1 defense and draws 1 card and worth 1 VP."
+    },
+    "ScoutLeader": {
+        "cost": 4,
+        "coins": 2,
+        "attack": 1,
+        "defense": 2,
+        "extraDraw": 2,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 2 coins and adds 1 attack and provides 2 defense and draws 2 cards and worth 1 VP."
+    },
+    "Rifleman": {
+        "cost": 3,
+        "coins": 1,
+        "attack": 1,
+        "defense": 2,
+        "vp": 2,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and provides 2 defense and worth 2 VP."
+    },
+    "Longbowman": {
+        "cost": 2,
+        "attack": 1,
+        "defense": 1,
+        "extraDraw": 1,
+        "vp": 2,
+        "emoji": "",
+        "description": "Adds 1 attack and provides 1 defense and draws 1 card and worth 2 VP."
+    },
+    "CaravanGuard": {
+        "cost": 6,
+        "coins": 1,
+        "attack": 1,
+        "defense": 1,
+        "vp": 1,
+        "emoji": "",
+        "description": "Gives 1 coin and adds 1 attack and provides 1 defense and worth 1 VP."
+    },
+    "Steward": {
+        "cost": 7,
+        "attack": 2,
+        "emoji": "",
+        "description": "Adds 2 attack."
+    }
+}


### PR DESCRIPTION
## Summary
- place all card definitions in `js/cards.json`
- load `cards.json` at runtime and remove the generation loop
- document how to edit card data in README
- add multiplier/divider effects and cards using them
- expand card list to over 230 unique entries

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6847b6955278832cbf96ddef5ff763aa