### PR TITLE
Fix GitHub Pages permission issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,14 @@ jobs:
 
       - name: Configure Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: false
+
+      - name: Lint game code
+        run: node --check js/app.js
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
 
@@ -39,5 +44,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3
 


### PR DESCRIPTION
## Summary
- prevent `actions/configure-pages` from trying to create the site

## Testing
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6847c2465220832c905db40d9d24b457