### PR TITLE
Implement health/shield gameplay

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,9 +39,22 @@ h1 {
     margin-bottom: 4px;
 }
 
+
 .market-card,
 .hand-card {
-    /* Classes kept for future extension */
+    /* wrapper styles */
+}
+
+.hand-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 5px;
+    width: 150px;
+}
+
+.hand-card .card {
+    margin: 0 0 4px 0;
 }
 
 /* wrapper around market cards to hold controls */

--- a/index.html
+++ b/index.html
@@ -19,6 +19,8 @@
                Round: <span id="roundNumber">1</span></p>
             <p>Coins: <span id="coinCount">0</span> |
                VP: <span id="vpCount">0</span></p>
+            <p>Health: <span id="health">20</span> |
+               Shield: <span id="shield">0</span></p>
         </div>
 
         <div id="aiInfo">
@@ -26,6 +28,8 @@
                AI Discard: <span id="aiDiscardCount">0</span></p>
             <p>AI Coins: <span id="aiCoinCount">0</span> |
                AI VP: <span id="aiVpCount">0</span></p>
+            <p>AI Health: <span id="aiHealth">20</span> |
+               AI Shield: <span id="aiShield">0</span></p>
         </div>
         </div>
 


### PR DESCRIPTION
## Summary
- adjust all card costs using a simple impact formula
- add player and AI health/shield displays
- enable using cards from the hand to deal damage or gain shield
- update AI to play its cards and attack
- new win condition when either side's health is depleted

## Testing
- `node --check js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_6847c763689c832cb4c84b64e3bd4fb7