### PR TITLE
Handle separate person card costs

### DIFF
--- a/actions.json
+++ b/actions.json
@@ -1,0 +1,162 @@
+[
+  {
+    "name": "Distraction",
+    "desc": "1 Action Pt.<br>2 Distraction<br>+1 Action Point"
+  },
+  {
+    "name": "Distraction",
+    "desc": "1 Action Pt.<br>3 Distraction<br>+1 Action Point"
+  },
+  {
+    "name": "Distraction",
+    "desc": "1 Action Pt.<br>4 Distraction<br>Scry 2 in Person Deck"
+  },
+  {
+    "name": "Intimidation",
+    "desc": "1 Action Pt.<br>2 Intimidation"
+  },
+  {
+    "name": "Intimidation",
+    "desc": "1 Action Pt.<br>3 Intimidation"
+  },
+  {
+    "name": "Intimidation",
+    "desc": "1 Action Pt.<br>4 Intimidation"
+  },
+  {
+    "name": "Bribery",
+    "desc": "1 Action Pt.<br>2 Distraction/Intimidation"
+  },
+  {
+    "name": "Bribery",
+    "desc": "1 Action Pt.<br>3 Distraction/Intimidation"
+  },
+  {
+    "name": "Bribery",
+    "desc": "1 Action Pt.<br>4 Distraction/Intimidation"
+  },
+  {
+    "name": "Deception",
+    "desc": "1 Action Pt.<br>2 Deception"
+  },
+  {
+    "name": "Deception",
+    "desc": "1 Action Pt.<br>3 Deception<br>Draw 1 card"
+  },
+  {
+    "name": "Deception",
+    "desc": "1 Action Pt.<br>4 Deception<br>Draw 1 card"
+  },
+  {
+    "name": "Distraction",
+    "desc": ""
+  },
+  {
+    "name": "Juggling Demonstration",
+    "desc": "Action<br>1 Distraction<br>Reduce detection counter by 1. Gain an affiliation."
+  },
+  {
+    "name": "UFO Sighting",
+    "desc": "Action <br>1 Distraction<br>Ignore person requirements for this turn."
+  },
+  {
+    "name": "Soccer-goal Celebration",
+    "desc": "Action <br>1 Distraction<br>Trigger target person card's effect."
+  },
+  {
+    "name": "Tell a Stranger a little too much",
+    "desc": "Action <br>4 Distraction<br>Advance detection counter, witness of your choice becomes an ally."
+  },
+  {
+    "name": "Throw the First Pitch",
+    "desc": "Action <br>2 Distraction<br>Put target card in your discard pile into your hand."
+  },
+  {
+    "name": "Trip to Lost & Found",
+    "desc": "Action <br>2 Distraction<br>Put target card in evidence back into the deck."
+  },
+  {
+    "name": "Smoke Break",
+    "desc": "Action <br>3 Distraction<br>Target player draws a card."
+  },
+  {
+    "name": "Intimidation",
+    "desc": ""
+  },
+  {
+    "name": "Cut in Line",
+    "desc": "Action <br>1 Intimidation<br>Reduce detection by 2. Draw a person card."
+  },
+  {
+    "name": "Chop Wood",
+    "desc": "Action <br>2 Intimidation<br>Reduce detection counter 1 for each card discarded this turn."
+  },
+  {
+    "name": "Clean the Gun",
+    "desc": "Action <br>2 Intimidation<br>Play target action card from evidence and then place it at the bottom of the deck."
+  },
+  {
+    "name": "Punch the Clock",
+    "desc": "Action <br>3 Intimidation<br>Scry 1, then draw 1."
+  },
+  {
+    "name": "Check My Pockets",
+    "desc": "Action <br>4 Intimidation<br>Put the top 2 cards of the deck onto the map. For each item card, reduce detection counter 1"
+  },
+  {
+    "name": "Deception",
+    "desc": ""
+  },
+  {
+    "name": "Spikey Hair Visor",
+    "desc": "Disguise<br>2 Deception"
+  },
+  {
+    "name": "Ask for Directions",
+    "desc": "Action<br>2 Deception<br>Trigger the effect of any Action or Item card on the Map, normal costs apply."
+  },
+  {
+    "name": "Magic Trick ",
+    "desc": "Action <br>3 Deception<br>Each player gives 1 card to the player on on their left."
+  },
+  {
+    "name": "Hallway Bump",
+    "desc": "Action <br>4 Deception<br>Advance the detection counter 1, each player gains and 1 affiliation or draws a card."
+  },
+  {
+    "name": "Bribery",
+    "desc": ""
+  },
+  {
+    "name": "Flick a Gold Coin",
+    "desc": "Action <br>1 Bribery<br>Reduce detection counter by 1."
+  },
+  {
+    "name": "Pay Someone to Dig a Hole",
+    "desc": "Action <br>2 Bribery<br>Put target item card from evidence into play."
+  },
+  {
+    "name": "One Last Round",
+    "desc": "Action <br>4 Bribery<br>Turn one person into an ally."
+  },
+  {
+    "name": "Multi",
+    "desc": ""
+  },
+  {
+    "name": "Break into a Car",
+    "desc": "Action <br>1 Deception, 1 Distraction<br>Put an item card from your hand on the map and draw two cards."
+  },
+  {
+    "name": "Deliver Giant Check & Balloons",
+    "desc": "Action <br>2 Bribery, 1 Distraction<br>Shuffle up to 3 evidence in o the deck."
+  },
+  {
+    "name": "Happy Hour",
+    "desc": "Action <br>2 Deception, 1 Distraction<br>Look at the top card of your deck, if it's an item, put it into your hand."
+  },
+  {
+    "name": "Lucky Trip to the Dump",
+    "desc": "Action <br>2 Bribery, 1 Distraction<br>Put a card from the map on the bottom of the deck."
+  }
+]

--- a/items.json
+++ b/items.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "Distraction",
+    "desc": ""
+  },
+  {
+    "name": "Pawn Broker Connection ",
+    "desc": "Item<br>1 Distraction<br>When another player gains an affiliation, you may discard a card to gain 2 affiliation points."
+  },
+  {
+    "name": "Bullhorn",
+    "desc": "Item<br>1 Distraction<br>When a person comes into play, you may advance the detection counter, if you do, everyone gains an affiliation point in Distraction."
+  },
+  {
+    "name": "Errant Frisbee",
+    "desc": "Item<br>1 Distraction<br>Once per turn, when a player draws a card, you may sacrifice an equipped item. If you do, draw 2 cards."
+  },
+  {
+    "name": "Free Pile Score",
+    "desc": "Item<br>1 Distraction<br>Once per turn, when a player discards a card, you may gain an affiliation point."
+  },
+  {
+    "name": "Busted Muffler",
+    "desc": "Item<br>2 Distraction<br>When a player plays an item, you may pay an affiliation to reduce the detection counter by 1."
+  },
+  {
+    "name": "Deception",
+    "desc": ""
+  },
+  {
+    "name": "Damaged Duffel",
+    "desc": "Item<br>1 Deception<br>When an item goes into evidence from play, you may gain an affiliation point."
+  },
+  {
+    "name": "Shiny Shovel",
+    "desc": "Item<br>1 Deception<br>When a player draws a card, you may discard a card. If you do, gain 2 affiliation points."
+  },
+  {
+    "name": "Lost Wallet",
+    "desc": "Item<br>1 Deception<br>Once per turn, when a player discards a card, you may draw a card or gain an affiliation point."
+  },
+  {
+    "name": "Large Cigar",
+    "desc": "Item<br>1 Deception<br>Once per turn, when a player plays an item, you may discard a card to gain 2 affiliation points."
+  },
+  {
+    "name": "Dark Scarf",
+    "desc": "Item<br>1 Deception<br>When a player gains an affiliation point, you may draw a card, if you do, discard a card.<br>x2 Deception Action Points"
+  },
+  {
+    "name": "Bribery",
+    "desc": ""
+  },
+  {
+    "name": "Padded Pocket",
+    "desc": "Item<br>1 Bribery<br>When a person becomes an ally, you may pay an affiliation point to reduce the detection counter 1."
+  },
+  {
+    "name": "Birder’s Binoculars",
+    "desc": "Item<br>1 Bribery<br>Once per turn, when a player draws a card, scry 2."
+  },
+  {
+    "name": "Fragrant Cologne",
+    "desc": "Item<br>1 Bribery<br>Once per turn, when a player plays an item, gain an affiliation."
+  },
+  {
+    "name": "Money on the Ground",
+    "desc": "Item<br>1 Bribery<br>Once per turn, when a player plays an item, you may discard a card to reduce the detection counter."
+  },
+  {
+    "name": "Martini Shaker",
+    "desc": "Item <br>1 Bribery<br>When a player gains an affiliation point, scry 1."
+  },
+  {
+    "name": "Security Camera",
+    "desc": "Item<br>1 Bribery<br>Once per turn, when a player gains an affiliation point, scry 1 and draw a card.<br>x2 Bribery Action Points"
+  },
+  {
+    "name": "Intimidation",
+    "desc": ""
+  },
+  {
+    "name": "Turnstyle",
+    "desc": "Item<br>1 Intimidation <br>Once per turn, when a player draws a card, you may shuffle an ally into the person deck. If you do, draw 2 cards."
+  },
+  {
+    "name": "Compost Bin ",
+    "desc": "Item<br>1 Intimidation<br>Once per turn, when a player discards a card, you may put the top card of the deck into evidence to reduce the detection counter 1."
+  },
+  {
+    "name": "Shopping Bag",
+    "desc": "Item<br>1 Intimidation<br>Once per turn, when a player plays an item, draw a card."
+  },
+  {
+    "name": "Carbon-fiber Road Bike",
+    "desc": "Item<br>2 Bribery, 1 Deception<br>Once per turn, when a player draws a card, you may pay an affiliation point. If you do, draw 2 cards."
+  },
+  {
+    "name": "Trail Camera",
+    "desc": "Item<br>1 Distraction, 2 Deception<br>Once per turn, when a player discards a card, advance the detection counter and each player draws a card or gains an affiliation."
+  },
+  {
+    "name": "Wood Chipper",
+    "desc": "Item<br>1 Bribery, 1 Intimidation<br>Once per turn, when a player discards a card, you may sacrifice an item. If you do, reduce the detection counter by 1."
+  },
+  {
+    "name": "Vanity Mirror",
+    "desc": "Item<br>1 Distraction, 1 Bribery<br>When a player gains an affiliation point, discard a card to reduce the detection counter 1<br>x2 Distraction Action Points"
+  },
+  {
+    "name": "Trusty Baseball Bat",
+    "desc": "Item<br>2 Intimidation, 1 Deception<br>Once per turn, when a player gains an affiliation point, gain an affiliation from among allies affiliations.<br>x2 Intimidation Action Points"
+  }
+]

--- a/map.json
+++ b/map.json
@@ -1,0 +1,80 @@
+[
+  {
+    "name": "Sneaky Shed [Everyone]",
+    "effects": [
+      "Trade Cards and Affiliation at 1:1",
+      "Trade cards with other players"
+    ]
+  },
+  {
+    "name": "Lou's Law Practice",
+    "effects": [
+      "Flip 1 Person",
+      "Draw 1 or Gain 1 Affiliation"
+    ]
+  },
+  {
+    "name": "The Run-down Corner",
+    "effects": [
+      "Flip 1 Person",
+      "Discard a card: Gain 1 affiliation."
+    ]
+  },
+  {
+    "name": "Behind Sam's Sausages",
+    "effects": [
+      "Flip 1 Person",
+      "Draw 2 cards, put 1 into your cache and the other on the bottom of the deck."
+    ]
+  },
+  {
+    "name": "Farmers Market",
+    "effects": [
+      "Draw 1 or Gain 1 Affiliation",
+      "Flip 1 Person"
+    ]
+  },
+  {
+    "name": "Sneaky Shed [Everyone]",
+    "effects": [
+      "Draw 3 cards and put 1 into your cache. Repeat 5 times.",
+      "Trade Cards and Affiliation at 1:1",
+      "Trade cards with other players"
+    ]
+  },
+  {
+    "name": "Harry's Hotdogs",
+    "effects": [
+      "Flip 2 person",
+      "Draw 1 or Get 1 Affiliation"
+    ]
+  },
+  {
+    "name": "Extra Funky Junkyard",
+    "effects": [
+      "Each player gains 1 affiliation.",
+      "Flip 1 Person",
+      "Discard 1 then draw 1. If no cards in hand, draw 2"
+    ]
+  },
+  {
+    "name": "Jamie's House",
+    "effects": [
+      "Get 2 Affiliation",
+      "Flip 1 Person"
+    ]
+  },
+  {
+    "name": "Pizza & Pilates",
+    "effects": [
+      "Flip 2 People",
+      "Draw 1 & Get 1 Affiliation"
+    ]
+  },
+  {
+    "name": "Dirty Dump [Everyone]",
+    "effects": [
+      "Pay 3 affiliation: Draw 3, put 1 in cache and others at the bottom of the deck."
+    ]
+  }
+]

--- a/people.json
+++ b/people.json
@@ -1,0 +1,154 @@
+[
+  {
+    "type": "person",
+    "name": "Banessica Murphries",
+    "cost1": "—-1 Deception, 1 Distraction—-",
+    "effect1": "1 Detection. If Banessica becomes a witness, flip 1 person.",
+    "cost2": "—-2 Intimidate, 4 Bribe—-",
+    "effect2": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Phil Ploe",
+    "cost1": "—-4 Distraction or Deception—-",
+    "effect1": "2 Detection",
+    "cost2": "—-1 Bribe—-",
+    "effect2": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "J.J. Millsap",
+    "cost1": "—-1 Deception, 1 Distraction—-",
+    "effect1": "3 Detection",
+    "cost2": "—-1 Bribe, 1 Intimidate—-",
+    "effect2": "Player with least cards in hand draw 1.<br>Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Quentarious Smith",
+    "cost1": "—-4 Distract—-",
+    "effect1": "1 Detection",
+    "cost2": "—-1 Intimidate—-",
+    "effect2": "Player with least affiliation gains 1.<br>Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Uncle Johnson I",
+    "cost1": "—-4 Distraction—-",
+    "effect1": "1 Detection",
+    "cost2": "—-5 Intimidation/Bribery—-",
+    "effect2": "If Uncle becomes a witness, all players lose 1 affiliation.<br>Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Vanessa Salmon",
+    "cost1": "—-4 Distraction—-",
+    "effect1": "1 Detection",
+    "cost2": "—-5 Intimidation—-",
+    "effect2": "All players discard a card, then draw a card.<br>If Vanessa becomes a witness, 1 player must discard a card."
+  },
+  {
+    "type": "person",
+    "name": "Craig Plompernickle",
+    "cost1": "—-4 Distraction—-",
+    "effect1": "1 Detection",
+    "cost2": "—-3 Intimidation, 2 Bribery—-",
+    "effect2": "All players discard a card.<br>Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Iris Geranium",
+    "cost1": "—-4 Distraction/Deception—-",
+    "effect1": "1 Detection",
+    "cost2": "—-3 Intimidation, 2 Bribery—-",
+    "effect2": "Player with the most Affiliation draw a card.<br>Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Yousef Brambler",
+    "cost1": "—-3 Distraction—-",
+    "effect1": "1 Detection. Each player discards a card.",
+    "cost2": "—-5 Intimidation—-",
+    "effect2": "Gain an Affiliation. Each player discards up to 3 cards and draws that many cards."
+  },
+  {
+    "type": "person",
+    "name": "Eric Dobben",
+    "cost1": "—-2 Deception—-",
+    "effect1": "1 Detection",
+    "cost2": "Trigger all previous witness effects in order.",
+    "effect2": "—-5 Bribery—-<br>Gain an Affiliation. Each player gains an affiliation."
+  },
+  {
+    "type": "person",
+    "name": "Mary Mousse-Ablebottom",
+    "cost1": "—-4 Deception/Distraction—-",
+    "effect1": "1 Detection",
+    "cost2": "—-3 Intimidation, 2 Bribery—-",
+    "effect2": "Gain an Affiliation. Each player draws a card and discards a card."
+  },
+  {
+    "type": "person",
+    "name": "Doug Ablebottom",
+    "cost1": "—-4 Distraction—-",
+    "effect1": "1 Detection. Each player passes a random card to the left.",
+    "cost2": "—-5 Intimidation—-",
+    "effect2": "Gain an Affiliation. Each player reveals their hand. Trades are free for the rest of the turn."
+  },
+  {
+    "type": "person",
+    "name": "Erika “Sunshine” Stinkfoot",
+    "cost1": "—-4 Distraction—-",
+    "effect1": "1 Detection. Each player discards a card or affiliation.",
+    "cost2": "—-4 Bribery—-",
+    "effect2": "Gain 1 affiliation. Each player draws a card and gains 1 affiliation."
+  },
+  {
+    "type": "person",
+    "name": "Ricardo Lapham",
+    "cost1": "—-2 Deception, 3 Distraction—-",
+    "effect1": "1 Detection",
+    "cost2": "—-2 Intimidation/ 2 Bribery—-",
+    "effect2": "All players must discard 1 item, if they have it. All players may draw a card.<br>Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Chord Michaelson Jr.",
+    "cost1": "—-4 Distraction—-",
+    "effect1": "1 Detection. Each player loses 1 Affiliation.",
+    "cost2": "—-5 Bribery—-",
+    "effect2": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+  },
+  {
+    "type": "person",
+    "name": "Sissy McGibbons",
+    "cost1": "—-2 Deception, 2 Distraction—-",
+    "effect1": "1 Detection",
+    "cost2": "—-5 Intimidation—-",
+    "effect2": "You may discard a card and draw a card. All players draw a card and gain 2 Affiliation"
+  },
+  {
+    "type": "person",
+    "name": "Gabe Bagletone",
+    "cost1": "—-1 Deception each witness in play—-",
+    "effect1": "1 Detection. Each player lose 1 Affiliation.",
+    "cost2": "—-4 Intimidation—-",
+    "effect2": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck.<br>Gain 1 affiliation. Players may discard 1 card to gain 1 Affiliation."
+  },
+  {
+    "type": "person",
+    "name": "Namkita Param",
+    "cost1": "—-3 Distraction—-",
+    "effect1": "1 Detection",
+    "cost2": "—-5 Bribery—-",
+    "effect2": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck.<br>All players gain 1 affiliation."
+  },
+  {
+    "type": "person",
+    "name": "Add a car freshener to the game as prize for winning (Head Cleaner)",
+    "cost1": "",
+    "effect1": "",
+    "cost2": "",
+    "effect2": ""
+  }
+]

--- a/rules.txt
+++ b/rules.txt
@@ -20,7 +20,7 @@ At any point during the turn the active player may choose to deal with people in
 Once all map card effects are resolved, trigger all detection counter effects, and pass turn to the next player.
 
 Dealing with People
-When a person is revealed, the active player has priority when dealing with that person. If they chose not to resolve any of the requirements, priority is passed to the next player to respond. They will get all the rewards listed on the card, but may agree with other players to split those rewards in some manner.
+When a person is revealed, the card shows two separate costs. The first cost may be paid to avoid the top effect. If no player pays that cost, the first effect resolves. After that, any player may pay the second cost to trigger the bottom effect. If nobody pays the second cost, the bottom effect does not occur. Priority begins with the active player and passes clockwise for each cost. Players who pay a cost gain any rewards from the associated effect and may share them however they like.
 If a person is not dealt with, the card moves to the next open person slot in the detection counter. (left to right)
 
 Ending The Game

--- a/style.css
+++ b/style.css
@@ -97,3 +97,12 @@ button {
     justify-content: center;
     margin-top: 5px;
 }
+
+.cost {
+    font-weight: bold;
+    margin-bottom: 2px;
+}
+
+.effect {
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- expand rules on paying costs for person cards
- parse people deck into cost and effect fields
- enforce avoidance and reward costs when a person is flipped
- style cost and effect sections on person cards
- load card decks from JSON
- store map card text as arrays for easier parsing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851d80be928832cad3f85dd48fd9788