### PR TITLE
Wrap card effects in objects

### DIFF
--- a/actions.json
+++ b/actions.json
@@ -1,0 +1,389 @@
+[
+  {
+    "name": "Distraction",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_distraction",
+        "amount": 2,
+        "text": "2 Distraction"
+      },
+      {
+        "id": "gain_action_point",
+        "amount": 1,
+        "text": "+1 Action Point"
+      }
+    ]
+  },
+  {
+    "name": "Distraction",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_distraction",
+        "amount": 3,
+        "text": "3 Distraction"
+      },
+      {
+        "id": "gain_action_point",
+        "amount": 1,
+        "text": "+1 Action Point"
+      }
+    ]
+  },
+  {
+    "name": "Distraction",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_distraction",
+        "amount": 4,
+        "text": "4 Distraction"
+      },
+      {
+        "id": "scry",
+        "amount": 2,
+        "text": "Scry 2 in Person Deck"
+      }
+    ]
+  },
+  {
+    "name": "Intimidation",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_intimidation",
+        "amount": 2,
+        "text": "2 Intimidation"
+      }
+    ]
+  },
+  {
+    "name": "Intimidation",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_intimidation",
+        "amount": 3,
+        "text": "3 Intimidation"
+      }
+    ]
+  },
+  {
+    "name": "Intimidation",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_intimidation",
+        "amount": 4,
+        "text": "4 Intimidation"
+      }
+    ]
+  },
+  {
+    "name": "Bribery",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_distraction_or_intimidation",
+        "amount": 2,
+        "text": "2 Distraction/Intimidation"
+      }
+    ]
+  },
+  {
+    "name": "Bribery",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_distraction_or_intimidation",
+        "amount": 3,
+        "text": "3 Distraction/Intimidation"
+      }
+    ]
+  },
+  {
+    "name": "Bribery",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_distraction_or_intimidation",
+        "amount": 4,
+        "text": "4 Distraction/Intimidation"
+      }
+    ]
+  },
+  {
+    "name": "Deception",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_deception",
+        "amount": 2,
+        "text": "2 Deception"
+      }
+    ]
+  },
+  {
+    "name": "Deception",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_deception",
+        "amount": 3,
+        "text": "3 Deception"
+      },
+      {
+        "id": "draw",
+        "amount": 1,
+        "text": "Draw 1 card"
+      }
+    ]
+  },
+  {
+    "name": "Deception",
+    "cost": "1 Action Pt.",
+    "effects": [
+      {
+        "id": "gain_deception",
+        "amount": 4,
+        "text": "4 Deception"
+      },
+      {
+        "id": "draw",
+        "amount": 1,
+        "text": "Draw 1 card"
+      }
+    ]
+  },
+  {
+    "name": "Juggling Demonstration",
+    "cost": "1 Distraction",
+    "effects": [
+      {
+        "id": "detection",
+        "amount": -1,
+        "text": "Reduce detection counter by 1. Gain an affiliation."
+      }
+    ]
+  },
+  {
+    "name": "UFO Sighting",
+    "cost": "1 Distraction",
+    "effects": [
+      {
+        "id": "ignore_person_requirements",
+        "text": "Ignore person requirements for this turn."
+      }
+    ]
+  },
+  {
+    "name": "Soccer-goal Celebration",
+    "cost": "1 Distraction",
+    "effects": [
+      {
+        "id": "trigger_person_effect",
+        "text": "Trigger target person card's effect."
+      }
+    ]
+  },
+  {
+    "name": "Tell a Stranger a little too much",
+    "cost": "4 Distraction",
+    "effects": [
+      {
+        "id": "detection",
+        "amount": 1,
+        "text": "Advance detection counter"
+      },
+      {
+        "id": "turn_ally",
+        "text": "Witness of your choice becomes an ally."
+      }
+    ]
+  },
+  {
+    "name": "Throw the First Pitch",
+    "cost": "2 Distraction",
+    "effects": [
+      {
+        "id": "recover_from_discard",
+        "text": "Put target card in your discard pile into your hand."
+      }
+    ]
+  },
+  {
+    "name": "Trip to Lost & Found",
+    "cost": "2 Distraction",
+    "effects": [
+      {
+        "id": "return_evidence",
+        "text": "Put target card in evidence back into the deck."
+      }
+    ]
+  },
+  {
+    "name": "Smoke Break",
+    "cost": "3 Distraction",
+    "effects": [
+      {
+        "id": "target_draw",
+        "text": "Target player draws a card."
+      }
+    ]
+  },
+  {
+    "name": "Cut in Line",
+    "cost": "1 Intimidation",
+    "effects": [
+      {
+        "id": "reduce_detection_draw_person",
+        "text": "Reduce detection by 2. Draw a person card."
+      }
+    ]
+  },
+  {
+    "name": "Chop Wood",
+    "cost": "2 Intimidation",
+    "effects": [
+      {
+        "id": "detection",
+        "amount": -1,
+        "text": "Reduce detection counter 1 for each card discarded this turn."
+      }
+    ]
+  },
+  {
+    "name": "Clean the Gun",
+    "cost": "2 Intimidation",
+    "effects": [
+      {
+        "id": "play_action_from_evidence",
+        "text": "Play target action card from evidence and then place it at the bottom of the deck."
+      }
+    ]
+  },
+  {
+    "name": "Punch the Clock",
+    "cost": "3 Intimidation",
+    "effects": [
+      {
+        "id": "draw",
+        "amount": 1,
+        "text": "Scry 1, then draw 1."
+      }
+    ]
+  },
+  {
+    "name": "Check My Pockets",
+    "cost": "4 Intimidation",
+    "effects": [
+      {
+        "id": "detection",
+        "amount": -1,
+        "text": "Put the top 2 cards of the deck onto the map. For each item card, reduce detection counter 1"
+      }
+    ]
+  },
+  {
+    "name": "Ask for Directions",
+    "cost": "2 Deception",
+    "effects": [
+      {
+        "id": "trigger_map_card_effect",
+        "text": "Trigger the effect of any Action or Item card on the Map, normal costs apply."
+      }
+    ]
+  },
+  {
+    "name": "Magic Trick ",
+    "cost": "3 Deception",
+    "effects": [
+      {
+        "id": "pass_left",
+        "text": "Each player gives 1 card to the player on on their left."
+      }
+    ]
+  },
+  {
+    "name": "Hallway Bump",
+    "cost": "4 Deception",
+    "effects": [
+      {
+        "id": "bump_and_choice",
+        "text": "Advance the detection counter 1, each player gains 1 affiliation or draws a card."
+      }
+    ]
+  },
+  {
+    "name": "Flick a Gold Coin",
+    "cost": "1 Bribery",
+    "effects": [
+      {
+        "id": "detection",
+        "amount": -1,
+        "text": "Reduce detection counter by 1."
+      }
+    ]
+  },
+  {
+    "name": "Pay Someone to Dig a Hole",
+    "cost": "2 Bribery",
+    "effects": [
+      {
+        "id": "play_item_from_evidence",
+        "text": "Put target item card from evidence into play."
+      }
+    ]
+  },
+  {
+    "name": "One Last Round",
+    "cost": "4 Bribery",
+    "effects": [
+      {
+        "id": "turn_ally",
+        "text": "Turn one person into an ally."
+      }
+    ]
+  },
+  {
+    "name": "Break into a Car",
+    "cost": "1 Deception, 1 Distraction",
+    "effects": [
+      {
+        "id": "drop_item_draw_two",
+        "text": "Put an item card from your hand on the map and draw two cards."
+      }
+    ]
+  },
+  {
+    "name": "Deliver Giant Check & Balloons",
+    "cost": "2 Bribery, 1 Distraction",
+    "effects": [
+      {
+        "id": "shuffle_evidence",
+        "text": "Shuffle up to 3 evidence into the deck."
+      }
+    ]
+  },
+  {
+    "name": "Happy Hour",
+    "cost": "2 Deception, 1 Distraction",
+    "effects": [
+      {
+        "id": "peek_item_into_hand",
+        "text": "Look at the top card of your deck, if it's an item, put it into your hand."
+      }
+    ]
+  },
+  {
+    "name": "Lucky Trip to the Dump",
+    "cost": "2 Bribery, 1 Distraction",
+    "effects": [
+      {
+        "id": "bottom_map_card",
+        "text": "Put a card from the map on the bottom of the deck."
+      }
+    ]
+  }
+]

--- a/items.json
+++ b/items.json
@@ -1,0 +1,272 @@
+[
+  {
+    "name": "Pawn Broker Connection ",
+    "cost": "1 Distraction",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 2,
+        "text": "When another player gains an affiliation, you may discard a card to gain 2 affiliation points."
+      }
+    ]
+  },
+  {
+    "name": "Bullhorn",
+    "cost": "1 Distraction",
+    "effects": [
+      {
+        "id": "advance_detection_all_gain_distraction",
+        "text": "When a person comes into play, you may advance the detection counter, if you do, everyone gains an affiliation point in Distraction."
+      }
+    ]
+  },
+  {
+    "name": "Errant Frisbee",
+    "cost": "1 Distraction",
+    "effects": [
+      {
+        "id": "draw",
+        "amount": 2,
+        "text": "Once per turn, when a player draws a card, you may sacrifice an equipped item. If you do, draw 2 cards."
+      }
+    ]
+  },
+  {
+    "name": "Free Pile Score",
+    "cost": "1 Distraction",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 1,
+        "text": "Once per turn, when a player discards a card, you may gain an affiliation point."
+      }
+    ]
+  },
+  {
+    "name": "Busted Muffler",
+    "cost": "2 Distraction",
+    "effects": [
+      {
+        "id": "pay_affiliation_reduce_detection_on_item_play",
+        "text": "When a player plays an item, you may pay an affiliation to reduce the detection counter by 1."
+      }
+    ]
+  },
+  {
+    "name": "Damaged Duffel",
+    "cost": "1 Deception",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 1,
+        "text": "When an item goes into evidence from play, you may gain an affiliation point."
+      }
+    ]
+  },
+  {
+    "name": "Shiny Shovel",
+    "cost": "1 Deception",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 2,
+        "text": "When a player draws a card, you may discard a card. If you do, gain 2 affiliation points."
+      }
+    ]
+  },
+  {
+    "name": "Lost Wallet",
+    "cost": "1 Deception",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 1,
+        "text": "Once per turn, when a player discards a card, you may draw a card or gain an affiliation point."
+      }
+    ]
+  },
+  {
+    "name": "Large Cigar",
+    "cost": "1 Deception",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 2,
+        "text": "Once per turn, when a player plays an item, you may discard a card to gain 2 affiliation points."
+      }
+    ]
+  },
+  {
+    "name": "Dark Scarf",
+    "cost": "1 Deception",
+    "effects": [
+      {
+        "id": "draw_then_discard_on_affiliation",
+        "text": "When a player gains an affiliation point, you may draw a card, if you do, discard a card."
+      },
+      {
+        "id": "double_deception_actions",
+        "text": "x2 Deception Action Points"
+      }
+    ]
+  },
+  {
+    "name": "Padded Pocket",
+    "cost": "1 Bribery",
+    "effects": [
+      {
+        "id": "pay_affiliation_reduce_detection_on_ally",
+        "text": "When a person becomes an ally, you may pay an affiliation point to reduce the detection counter 1."
+      }
+    ]
+  },
+  {
+    "name": "Birder’s Binoculars",
+    "cost": "1 Bribery",
+    "effects": [
+      {
+        "id": "scry",
+        "amount": 2,
+        "text": "Once per turn, when a player draws a card, scry 2."
+      }
+    ]
+  },
+  {
+    "name": "Fragrant Cologne",
+    "cost": "1 Bribery",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 1,
+        "text": "Once per turn, when a player plays an item, gain an affiliation."
+      }
+    ]
+  },
+  {
+    "name": "Money on the Ground",
+    "cost": "1 Bribery",
+    "effects": [
+      {
+        "id": "discard_reduce_detection_on_item_play",
+        "text": "Once per turn, when a player plays an item, you may discard a card to reduce the detection counter."
+      }
+    ]
+  },
+  {
+    "name": "Martini Shaker",
+    "cost": "1 Bribery",
+    "effects": [
+      {
+        "id": "scry",
+        "amount": 1,
+        "text": "When a player gains an affiliation point, scry 1."
+      }
+    ]
+  },
+  {
+    "name": "Security Camera",
+    "cost": "1 Bribery",
+    "effects": [
+      {
+        "id": "scry",
+        "amount": 1,
+        "text": "Once per turn, when a player gains an affiliation point, scry 1 and draw a card."
+      },
+      {
+        "id": "double_bribery_actions",
+        "text": "x2 Bribery Action Points"
+      }
+    ]
+  },
+  {
+    "name": "Turnstyle",
+    "cost": "1 Intimidation",
+    "effects": [
+      {
+        "id": "draw",
+        "amount": 2,
+        "text": "Once per turn, when a player draws a card, you may shuffle an ally into the person deck. If you do, draw 2 cards."
+      }
+    ]
+  },
+  {
+    "name": "Compost Bin ",
+    "cost": "1 Intimidation",
+    "effects": [
+      {
+        "id": "sacrifice_top_to_evidence_reduce_detection",
+        "text": "Once per turn, when a player discards a card, you may put the top card of the deck into evidence to reduce the detection counter 1."
+      }
+    ]
+  },
+  {
+    "name": "Shopping Bag",
+    "cost": "1 Intimidation",
+    "effects": [
+      {
+        "id": "draw_on_item_play",
+        "text": "Once per turn, when a player plays an item, draw a card."
+      }
+    ]
+  },
+  {
+    "name": "Carbon-fiber Road Bike",
+    "cost": "2 Bribery, 1 Deception",
+    "effects": [
+      {
+        "id": "draw",
+        "amount": 2,
+        "text": "Once per turn, when a player draws a card, you may pay an affiliation point. If you do, draw 2 cards."
+      }
+    ]
+  },
+  {
+    "name": "Trail Camera",
+    "cost": "1 Distraction, 2 Deception",
+    "effects": [
+      {
+        "id": "advance_detection_and_choice_on_discard",
+        "text": "Once per turn, when a player discards a card, advance the detection counter and each player draws a card or gains an affiliation."
+      }
+    ]
+  },
+  {
+    "name": "Wood Chipper",
+    "cost": "1 Bribery, 1 Intimidation",
+    "effects": [
+      {
+        "id": "sacrifice_item_reduce_detection",
+        "text": "Once per turn, when a player discards a card, you may sacrifice an item. If you do, reduce the detection counter by 1."
+      }
+    ]
+  },
+  {
+    "name": "Vanity Mirror",
+    "cost": "1 Distraction, 1 Bribery",
+    "effects": [
+      {
+        "id": "discard_on_affiliation_reduce_detection",
+        "text": "When a player gains an affiliation point, discard a card to reduce the detection counter 1"
+      },
+      {
+        "id": "double_distraction_actions",
+        "text": "x2 Distraction Action Points"
+      }
+    ]
+  },
+  {
+    "name": "Trusty Baseball Bat",
+    "cost": "2 Intimidation, 1 Deception",
+    "effects": [
+      {
+        "id": "affiliation",
+        "amount": 1,
+        "text": "Once per turn, when a player gains an affiliation point, gain an affiliation from among allies affiliations."
+      },
+      {
+        "id": "double_intimidation_actions",
+        "text": "x2 Intimidation Action Points"
+      }
+    ]
+  }
+]

--- a/map.json
+++ b/map.json
@@ -1,0 +1,166 @@
+[
+  {
+    "name": "Sneaky Shed [Everyone]",
+    "effects": [
+      {
+        "id": "trade_cards_affiliation",
+        "text": "Trade Cards and Affiliation at 1:1"
+      },
+      {
+        "id": "trade_cards_with_players",
+        "text": "Trade cards with other players"
+      }
+    ]
+  },
+  {
+    "name": "Lou's Law Practice",
+    "effects": [
+      {
+        "id": "flip",
+        "amount": 1,
+        "text": "Flip 1 Person"
+      },
+      {
+        "id": "draw_or_affiliation",
+        "amount": 1,
+        "text": "Draw 1 or Gain 1 Affiliation"
+      }
+    ]
+  },
+  {
+    "name": "The Run-down Corner",
+    "effects": [
+      {
+        "id": "flip",
+        "amount": 1,
+        "text": "Flip 1 Person"
+      },
+      {
+        "id": "affiliation",
+        "amount": 1,
+        "text": "Discard a card: Gain 1 affiliation."
+      }
+    ]
+  },
+  {
+    "name": "Behind Sam's Sausages",
+    "effects": [
+      {
+        "id": "flip",
+        "amount": 1,
+        "text": "Flip 1 Person"
+      },
+      {
+        "id": "draw",
+        "amount": 2,
+        "text": "Draw 2 cards, put 1 into your cache and the other on the bottom of the deck."
+      }
+    ]
+  },
+  {
+    "name": "Farmers Market",
+    "effects": [
+      {
+        "id": "draw_or_affiliation",
+        "amount": 1,
+        "text": "Draw 1 or Gain 1 Affiliation"
+      },
+      {
+        "id": "flip",
+        "amount": 1,
+        "text": "Flip 1 Person"
+      }
+    ]
+  },
+  {
+    "name": "Sneaky Shed [Everyone]",
+    "effects": [
+      {
+        "id": "draw",
+        "amount": 3,
+        "text": "Draw 3 cards and put 1 into your cache. Repeat 5 times."
+      },
+      {
+        "id": "trade_cards_affiliation",
+        "text": "Trade Cards and Affiliation at 1:1"
+      },
+      {
+        "id": "trade_cards_with_players",
+        "text": "Trade cards with other players"
+      }
+    ]
+  },
+  {
+    "name": "Harry's Hotdogs",
+    "effects": [
+      {
+        "id": "flip",
+        "amount": 2,
+        "text": "Flip 2 person"
+      },
+      {
+        "id": "draw_or_affiliation",
+        "amount": 1,
+        "text": "Draw 1 or Get 1 Affiliation"
+      }
+    ]
+  },
+  {
+    "name": "Extra Funky Junkyard",
+    "effects": [
+      {
+        "id": "each_gain_affiliation",
+        "text": "Each player gains 1 affiliation."
+      },
+      {
+        "id": "flip",
+        "amount": 1,
+        "text": "Flip 1 Person"
+      },
+      {
+        "id": "draw",
+        "amount": 1,
+        "text": "Discard 1 then draw 1. If no cards in hand, draw 2"
+      }
+    ]
+  },
+  {
+    "name": "Jamie's House",
+    "effects": [
+      {
+        "id": "gain_two_affiliation",
+        "text": "Get 2 Affiliation"
+      },
+      {
+        "id": "flip",
+        "amount": 1,
+        "text": "Flip 1 Person"
+      }
+    ]
+  },
+  {
+    "name": "Pizza & Pilates",
+    "effects": [
+      {
+        "id": "flip",
+        "amount": 2,
+        "text": "Flip 2 People"
+      },
+      {
+        "id": "draw",
+        "amount": 1,
+        "text": "Draw 1 & Get 1 Affiliation"
+      }
+    ]
+  },
+  {
+    "name": "Dirty Dump [Everyone]",
+    "effects": [
+      {
+        "id": "draw",
+        "amount": 3,
+        "text": "Pay 3 affiliation: Draw 3, put 1 in cache and others at the bottom of the deck."
+      }
+    ]
+  }
+]

--- a/people.json
+++ b/people.json
@@ -1,0 +1,478 @@
+[
+  {
+    "type": "person",
+    "name": "Banessica Murphries",
+    "avoid": {
+      "cost": "1 Deception, 1 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection. If Banessica becomes a witness, flip 1 person."
+        }
+      ]
+    },
+    "reward": {
+      "cost": "2 Intimidate, 4 Bribe",
+      "effects": [
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Phil Ploe",
+    "avoid": {
+      "cost": "4 Distraction or Deception",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 2,
+          "text": "2 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "1 Bribe",
+      "effects": [
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "J.J. Millsap",
+    "avoid": {
+      "cost": "1 Deception, 1 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 3,
+          "text": "3 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "1 Bribe, 1 Intimidate",
+      "effects": [
+        {
+          "id": "draw",
+          "amount": 1,
+          "text": "Player with least cards in hand draw 1."
+        },
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Quentarious Smith",
+    "avoid": {
+      "cost": "4 Distract",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "1 Intimidate",
+      "effects": [
+        {
+          "id": "least_affiliation_gain",
+          "text": "Player with least affiliation gains 1."
+        },
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Uncle Johnson I",
+    "avoid": {
+      "cost": "4 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "5 Intimidation/Bribery",
+      "effects": [
+        {
+          "id": "affiliation",
+          "amount": -1,
+          "text": "If Uncle becomes a witness, all players lose 1 affiliation."
+        },
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Vanessa Salmon",
+    "avoid": {
+      "cost": "4 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "5 Intimidation",
+      "effects": [
+        {
+          "id": "discard_then_draw_all",
+          "text": "All players discard a card, then draw a card."
+        },
+        {
+          "id": "witness_penalty_discard",
+          "text": "If Vanessa becomes a witness, 1 player must discard a card."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Craig Plompernickle",
+    "avoid": {
+      "cost": "4 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "3 Intimidation, 2 Bribery",
+      "effects": [
+        {
+          "id": "discard_all",
+          "text": "All players discard a card."
+        },
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Iris Geranium",
+    "avoid": {
+      "cost": "4 Distraction/Deception",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "3 Intimidation, 2 Bribery",
+      "effects": [
+        {
+          "id": "most_affiliation_draw",
+          "text": "Player with the most Affiliation draw a card."
+        },
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Yousef Brambler",
+    "avoid": {
+      "cost": "3 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection. Each player discards a card."
+        }
+      ]
+    },
+    "reward": {
+      "cost": "5 Intimidation",
+      "effects": [
+        {
+          "id": "affiliation",
+          "amount": 1,
+          "text": "Gain an Affiliation. Each player discards up to 3 cards and draws that many cards."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Eric Dobben",
+    "avoid": {
+      "cost": "2 Deception",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "Trigger all previous witness effects in order.",
+      "effects": [
+        {
+          "id": "gain_bribery",
+          "amount": 5,
+          "text": "5 Bribery"
+        },
+        {
+          "id": "affiliation",
+          "amount": 1,
+          "text": "Gain an Affiliation. Each player gains an affiliation."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Mary Mousse-Ablebottom",
+    "avoid": {
+      "cost": "4 Deception/Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "3 Intimidation, 2 Bribery",
+      "effects": [
+        {
+          "id": "affiliation",
+          "amount": 1,
+          "text": "Gain an Affiliation. Each player draws a card and discards a card."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Doug Ablebottom",
+    "avoid": {
+      "cost": "4 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection. Each player passes a random card to the left."
+        }
+      ]
+    },
+    "reward": {
+      "cost": "5 Intimidation",
+      "effects": [
+        {
+          "id": "affiliation",
+          "amount": 1,
+          "text": "Gain an Affiliation. Each player reveals their hand. Trades are free for the rest of the turn."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Erika “Sunshine” Stinkfoot",
+    "avoid": {
+      "cost": "4 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection. Each player discards a card or affiliation."
+        }
+      ]
+    },
+    "reward": {
+      "cost": "4 Bribery",
+      "effects": [
+        {
+          "id": "affiliation",
+          "amount": 1,
+          "text": "Gain 1 affiliation. Each player draws a card and gains 1 affiliation."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Ricardo Lapham",
+    "avoid": {
+      "cost": "2 Deception, 3 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "2 Intimidation/ 2 Bribery",
+      "effects": [
+        {
+          "id": "discard_item_optional_draw",
+          "text": "All players must discard 1 item, if they have it. All players may draw a card."
+        },
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Chord Michaelson Jr.",
+    "avoid": {
+      "cost": "4 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection. Each player loses 1 Affiliation."
+        }
+      ]
+    },
+    "reward": {
+      "cost": "5 Bribery",
+      "effects": [
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Sissy McGibbons",
+    "avoid": {
+      "cost": "2 Deception, 2 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "5 Intimidation",
+      "effects": [
+        {
+          "id": "affiliation",
+          "amount": 2,
+          "text": "You may discard a card and draw a card. All players draw a card and gain 2 Affiliation"
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Gabe Bagletone",
+    "avoid": {
+      "cost": "1 Deception each witness in play",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection. Each player lose 1 Affiliation."
+        }
+      ]
+    },
+    "reward": {
+      "cost": "4 Intimidation",
+      "effects": [
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        },
+        {
+          "id": "affiliation",
+          "amount": 1,
+          "text": "Gain 1 affiliation. Players may discard 1 card to gain 1 Affiliation."
+        }
+      ]
+    }
+  },
+  {
+    "type": "person",
+    "name": "Namkita Param",
+    "avoid": {
+      "cost": "3 Distraction",
+      "effects": [
+        {
+          "id": "detection",
+          "amount": 1,
+          "text": "1 Detection"
+        }
+      ]
+    },
+    "reward": {
+      "cost": "5 Bribery",
+      "effects": [
+        {
+          "id": "draw",
+          "amount": 2,
+          "text": "Draw 2 cards, then put 1 into your Cache and the other on the bottom of the deck."
+        },
+        {
+          "id": "affiliation",
+          "amount": 1,
+          "text": "All players gain 1 affiliation."
+        }
+      ]
+    }
+  }
+]

--- a/rules.txt
+++ b/rules.txt
@@ -20,7 +20,7 @@ At any point during the turn the active player may choose to deal with people in
 Once all map card effects are resolved, trigger all detection counter effects, and pass turn to the next player.
 
 Dealing with People
-When a person is revealed, the active player has priority when dealing with that person. If they chose not to resolve any of the requirements, priority is passed to the next player to respond. They will get all the rewards listed on the card, but may agree with other players to split those rewards in some manner.
+When a person is revealed, the card shows two separate costs. The first cost may be paid to avoid the top effect. If no player pays that cost, the first effect resolves. After that, any player may pay the second cost to trigger the bottom effect. If nobody pays the second cost, the bottom effect does not occur. Priority begins with the active player and passes clockwise for each cost. Players who pay a cost gain any rewards from the associated effect and may share them however they like.
 If a person is not dealt with, the card moves to the next open person slot in the detection counter. (left to right)
 
 Ending The Game

--- a/style.css
+++ b/style.css
@@ -97,3 +97,12 @@ button {
     justify-content: center;
     margin-top: 5px;
 }
+
+.cost {
+    font-weight: bold;
+    margin-bottom: 2px;
+}
+
+.effect {
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- give each custom effect a unique id based on its action text
- update map, item, action and person JSON files with these ids
- add `gain_action_point` handling in `runEffect`
- remove all empty placeholder cards from actions and items decks
- implement effect handlers for every effect id

## Testing
- `node -c script.js`
- `node -e "['actions.json','items.json','map.json','people.json'].forEach(f=>{JSON.parse(require('fs').readFileSync(f,'utf8'))});console.log('ok');"`


------
https://chatgpt.com/codex/tasks/task_e_6851d80be928832cad3f85dd48fd9788