### PR TITLE
Improve game UI layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <div class="container-fluid">
-<h1 class="text-center my-3">Board Game Helper</h1>
+<!-- Title removed per new layout -->
 <section id="setup" class="mb-3">
     <h2>Players</h2>
     <div class="row g-2 mb-2">
@@ -22,8 +22,7 @@
 </section>
 
 <section id="turn-info" style="display:none;" class="mb-3">
-    <h2>Current Player: <span id="current-player"></span></h2>
-    <p>Actions left: <span id="actions-left">3</span></p>
+    <p class="m-0"><strong>Current Player:</strong> <span id="current-player"></span> – <strong>Actions left:</strong> <span id="actions-left">3</span></p>
     <div id="action-info" style="display:none;" class="my-2">
         <p id="current-action" class="fw-bold"></p>
         <button id="resolve-action" class="btn btn-success btn-sm">Resolve Action</button>
@@ -34,21 +33,25 @@
     <div id="player1-area" class="player-area">
         <h3 class="player-name" id="player1-name"></h3>
         <p>Affiliation: <span class="affiliation" id="aff1">0</span></p>
+        <p class="deck-info">Deck: <span id="deck1-count">0</span> | Discard: <span id="discard1-count">0</span></p>
         <div class="hand" id="hand1"></div>
     </div>
     <div id="player2-area" class="player-area">
         <h3 class="player-name" id="player2-name"></h3>
         <p>Affiliation: <span class="affiliation" id="aff2">0</span></p>
+        <p class="deck-info">Deck: <span id="deck2-count">0</span> | Discard: <span id="discard2-count">0</span></p>
         <div class="hand" id="hand2"></div>
     </div>
     <div id="player3-area" class="player-area">
         <h3 class="player-name" id="player3-name"></h3>
         <p>Affiliation: <span class="affiliation" id="aff3">0</span></p>
+        <p class="deck-info">Deck: <span id="deck3-count">0</span> | Discard: <span id="discard3-count">0</span></p>
         <div class="hand" id="hand3"></div>
     </div>
     <div id="player4-area" class="player-area">
         <h3 class="player-name" id="player4-name"></h3>
         <p>Affiliation: <span class="affiliation" id="aff4">0</span></p>
+        <p class="deck-info">Deck: <span id="deck4-count">0</span> | Discard: <span id="discard4-count">0</span></p>
         <div class="hand" id="hand4"></div>
     </div>
     <div id="center-area" class="text-center">

--- a/script.js
+++ b/script.js
@@ -99,7 +99,14 @@ function updateTurnInfo(){
     document.getElementById('actions-left').textContent = actionsLeft;
     players.forEach((p, idx)=>{
         document.getElementById('aff'+(idx+1)).textContent = p.affiliation;
+        updatePlayerDeckInfo(idx);
     });
+}
+
+function updatePlayerDeckInfo(idx){
+    const p = players[idx];
+    document.getElementById('deck'+(idx+1)+'-count').textContent = p.deck.length;
+    document.getElementById('discard'+(idx+1)+'-count').textContent = p.discard.length;
 }
 
 function nextPlayer(){
@@ -139,11 +146,13 @@ function drawFromPlayerDeck(index){
         p.deck = p.discard;
         shuffle(p.deck);
         p.discard = [];
+        updatePlayerDeckInfo(index);
     }
     const card = p.deck.pop();
     p.hand.push(card);
     const area = handAreas[index];
     area.appendChild(createCardElement(card));
+    updatePlayerDeckInfo(index);
 }
 
 function renderMapTray(){
@@ -357,6 +366,7 @@ document.addEventListener('DOMContentLoaded',()=>{
                 area.querySelector('.player-name').textContent = nameInput;
                 handAreas.push(area.querySelector('.hand'));
                 area.querySelector('.affiliation').textContent = '0';
+                updatePlayerDeckInfo(players.length-1);
             } else {
                 area.style.display = 'none';
             }

--- a/style.css
+++ b/style.css
@@ -15,8 +15,8 @@ body {
     border-radius: 4px;
 }
 .game-card {
-    width: 100px;
-    height: 150px;
+    width: 120px;
+    height: 180px;
     border: 2px solid #333;
     border-radius: 8px;
     padding: 10px;
@@ -37,6 +37,9 @@ body {
 .game-card-body {
     font-size: 0.8em;
     text-align: center;
+    overflow-y: auto;
+    word-break: break-word;
+    flex-grow: 1;
 }
 button {
     margin-right: 5px;
@@ -101,6 +104,11 @@ button {
     flex-wrap: wrap;
     justify-content: center;
     margin-top: 5px;
+}
+
+.deck-info {
+    font-size: 0.8em;
+    margin-bottom: 4px;
 }
 
 .cost {


### PR DESCRIPTION
## Summary
- remove page title
- show turn info on one line
- keep cards uniform size and handle overflow
- display each player's deck and discard sizes

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_685218e69af0832c9ed0ac8480ab6fd5