### PR TITLE
Improve UX by replacing alert dialogs with modal prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     <p class="m-0"><strong>Current Player:</strong> <span id="current-player"></span> – <strong>Actions left:</strong> <span id="actions-left">3</span></p>
     <div id="action-info" style="display:none;" class="my-2">
         <p id="current-action" class="fw-bold"></p>
+        <p id="prompt-instruction" class="text-primary"></p>
         <button id="resolve-action" class="btn btn-success btn-sm">Resolve Action</button>
     </div>
     <button id="end-turn" class="btn btn-secondary">End Turn</button>
@@ -90,13 +91,25 @@
 <h2>Rules</h2>
 <pre id="rules-text"></pre>
 </section>
-<div class="toast-container position-fixed bottom-0 end-0 p-3">
-  <div id="message-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-body" id="toast-message"></div>
+    <div class="toast-container position-fixed bottom-0 end-0 p-3">
+      <div id="message-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="toast-body" id="toast-message"></div>
+      </div>
+    </div>
+    <div class="modal fade" id="prompt-modal" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="prompt-title"></h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body" id="prompt-body"></div>
+          <div class="modal-footer" id="prompt-footer"></div>
+        </div>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="script.js"></script>
   </div>
-</div>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="script.js"></script>
-</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Bootstrap modal to replace browser dialogs
- implement `showConfirmUI` and `showCardSelectionUI`
- refactor cost payment and draw/affiliation choices to use modal
- update person-flip action handlers to async/await
- await actions on resolve
- show prompt instructions in action info panel

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6852f5454f50832c91bad54b2d8e0fe8