### PR TITLE
Remove toast alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <button id="resolve-action" class="btn btn-success btn-sm">Resolve Action</button>
     </div>
     <button id="end-turn" class="btn btn-secondary">End Turn</button>
+    <div id="game-messages" class="text-danger my-2"></div>
 </section>
 <div id="board" style="display:none;" class="mb-3">
     <div id="player1-area" class="player-area">
@@ -91,11 +92,6 @@
 <h2>Rules</h2>
 <pre id="rules-text"></pre>
 </section>
-    <div class="toast-container position-fixed bottom-0 end-0 p-3">
-      <div id="message-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-        <div class="toast-body" id="toast-message"></div>
-      </div>
-    </div>
     <div class="modal fade" id="prompt-modal" tabindex="-1">
       <div class="modal-dialog">
         <div class="modal-content">

--- a/script.js
+++ b/script.js
@@ -18,11 +18,11 @@ let currentAction = null;
 let turnPhase = 'chooseMap';
 
 function showMessage(text){
-    const toastEl = document.getElementById('message-toast');
-    if(!toastEl) return; // no UI element available
-    document.getElementById('toast-message').textContent = text;
-    const toast = bootstrap.Toast.getOrCreateInstance(toastEl);
-    toast.show();
+    const msgEl = document.getElementById('game-messages');
+    if(!msgEl) return; // no UI element available
+    const div = document.createElement('div');
+    div.textContent = text;
+    msgEl.appendChild(div);
 }
 
 function showInstruction(text){

--- a/style.css
+++ b/style.css
@@ -119,3 +119,7 @@ button {
 .effect {
     margin-bottom: 4px;
 }
+
+#game-messages div {
+    margin-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- keep game messages in a visible area instead of showing Bootstrap toasts
- clean up the HTML layout and add new `#game-messages` container
- style the message list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852fb593dd4832cb69185641815cb09